### PR TITLE
Add persistent storage for adhkar and hadith endpoints

### DIFF
--- a/back/src/routes/adhkar.ts
+++ b/back/src/routes/adhkar.ts
@@ -1,7 +1,7 @@
 import express from "express";
 
 import { authenticate } from "../middleware/auth.js";
-import { getAdhkar } from "../services/dataService.js";
+import { getAdhkar, saveDhikrSet } from "../services/dataService.js";
 
 const router = express.Router();
 
@@ -13,7 +13,17 @@ router.get("/", (req, res) => {
 });
 
 router.post("/", authenticate(["admin", "teacher"]), (req, res) => {
-  res.json({ message: "تم حفظ الذكر (محاكاة)", payload: req.body });
+  try {
+    const saved = saveDhikrSet(req.body);
+    res.status(201).json({
+      message: "تم حفظ مجموعة الأذكار بنجاح",
+      set: saved,
+      all: getAdhkar()
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "تعذر حفظ مجموعة الأذكار";
+    res.status(400).json({ message });
+  }
 });
 
 export const adhkarRouter = router;

--- a/back/src/routes/hadith.ts
+++ b/back/src/routes/hadith.ts
@@ -1,7 +1,7 @@
 import express from "express";
 
 import { authenticate } from "../middleware/auth.js";
-import { getHadith } from "../services/dataService.js";
+import { getHadith, saveHadith } from "../services/dataService.js";
 
 const router = express.Router();
 
@@ -19,7 +19,17 @@ router.get("/", (req, res) => {
 });
 
 router.post("/", authenticate(["admin", "lecturer"]), (req, res) => {
-  res.json({ message: "تم حفظ الحديث (محاكاة)", payload: req.body });
+  try {
+    const saved = saveHadith(req.body);
+    res.status(201).json({
+      message: "تم حفظ الحديث بنجاح",
+      hadith: saved,
+      all: getHadith()
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "تعذر حفظ الحديث";
+    res.status(400).json({ message });
+  }
 });
 
 export const hadithRouter = router;

--- a/back/src/services/dataService.ts
+++ b/back/src/services/dataService.ts
@@ -59,6 +59,32 @@ export function getFaqs(): { question: string; answer: string }[] {
   return loadJson("faq_scholars.json");
 }
 
+function normalizeHadithTopics(topic: unknown): string[] | undefined {
+  if (topic == null) {
+    return undefined;
+  }
+
+  const topics = Array.isArray(topic) ? topic : [topic];
+  const normalized: string[] = [];
+
+  for (const entry of topics) {
+    if (entry == null) {
+      continue;
+    }
+
+    if (typeof entry === "object") {
+      throw new Error("موضوع الحديث يجب أن يكون نصًا صالحًا");
+    }
+
+    const coerced = String(entry).trim();
+    if (coerced) {
+      normalized.push(coerced);
+    }
+  }
+
+  return normalized.length ? normalized : undefined;
+}
+
 function normalizeDhikrItems(setId: string, items: Dhikr[]): Dhikr[] {
   return items.map((item, index) => {
     if (!item.text?.trim()) {
@@ -125,11 +151,7 @@ export function saveHadith(input: Partial<Hadith>): Hadith {
     number: input.number?.trim(),
     text_ar: input.text_ar.trim(),
     grade: input.grade?.trim(),
-    topic: Array.isArray(input.topic)
-      ? input.topic
-      : input.topic
-        ? [input.topic]
-        : undefined
+    topic: normalizeHadithTopics(input.topic)
   };
 
   const stored = readStoredJson<Hadith[]>("hadith_custom.json") ?? [];

--- a/back/src/services/dataService.ts
+++ b/back/src/services/dataService.ts
@@ -1,6 +1,10 @@
+import { v4 as uuid } from "uuid";
+
 import { loadJson } from "../utils/loadData.js";
+import { readStoredJson, writeStoredJson } from "../utils/storage.js";
 import type {
   Ayah,
+  Dhikr,
   DhikrSet,
   Hadith,
   Surah,
@@ -20,13 +24,123 @@ export function getTafsir(): Tafsir[] {
 }
 
 export function getAdhkar(): DhikrSet[] {
-  return loadJson<DhikrSet[]>("adhkar_sets.json");
+  const base = loadJson<DhikrSet[]>("adhkar_sets.json");
+  const stored = readStoredJson<DhikrSet[]>("adhkar_custom.json") ?? [];
+
+  const merged = new Map<string, DhikrSet>();
+  for (const set of base) {
+    merged.set(set.name, set);
+  }
+
+  for (const set of stored) {
+    merged.set(set.name, set);
+  }
+
+  return Array.from(merged.values());
 }
 
 export function getHadith(): Hadith[] {
-  return loadJson<Hadith[]>("hadith_samples.json");
+  const base = loadJson<Hadith[]>("hadith_samples.json");
+  const stored = readStoredJson<Hadith[]>("hadith_custom.json") ?? [];
+
+  const merged = new Map<string, Hadith>();
+  for (const hadith of base) {
+    merged.set(hadith.id, hadith);
+  }
+
+  for (const hadith of stored) {
+    merged.set(hadith.id, hadith);
+  }
+
+  return Array.from(merged.values());
 }
 
 export function getFaqs(): { question: string; answer: string }[] {
   return loadJson("faq_scholars.json");
+}
+
+function normalizeDhikrItems(setId: string, items: Dhikr[]): Dhikr[] {
+  return items.map((item, index) => {
+    if (!item.text?.trim()) {
+      throw new Error(`النص الأساسي للذكر رقم ${index + 1} مطلوب`);
+    }
+
+    return {
+      id: item.id?.trim() || `dhikr-${setId}-${index + 1}`,
+      title: item.title?.trim() || `ذكر ${index + 1}`,
+      text: item.text.trim(),
+      count: item.count,
+      tags: Array.isArray(item.tags) ? item.tags : [],
+      reference: item.reference?.trim() || undefined
+    } satisfies Dhikr;
+  });
+}
+
+export function saveDhikrSet(input: Partial<DhikrSet>): DhikrSet {
+  if (!input?.name?.trim()) {
+    throw new Error("اسم مجموعة الأذكار مطلوب");
+  }
+
+  if (!Array.isArray(input.items) || !input.items.length) {
+    throw new Error("يجب توفير أذكار واحدة على الأقل");
+  }
+
+  const setId = input.id?.trim() || `adhkar-${uuid()}`;
+  const normalized: DhikrSet = {
+    id: setId,
+    name: input.name.trim(),
+    title: input.title?.trim(),
+    description: input.description?.trim(),
+    items: normalizeDhikrItems(setId, input.items)
+  };
+
+  const stored = readStoredJson<DhikrSet[]>("adhkar_custom.json") ?? [];
+  const index = stored.findIndex((set) => set.id === normalized.id || set.name === normalized.name);
+
+  if (index >= 0) {
+    stored[index] = normalized;
+  } else {
+    stored.push(normalized);
+  }
+
+  writeStoredJson("adhkar_custom.json", stored);
+  return normalized;
+}
+
+export function saveHadith(input: Partial<Hadith>): Hadith {
+  if (!input?.text_ar?.trim()) {
+    throw new Error("متن الحديث مطلوب");
+  }
+
+  if (!input?.source?.trim()) {
+    throw new Error("مصدر الحديث مطلوب");
+  }
+
+  const hadithId = input.id?.trim() || `hadith-${uuid()}`;
+  const normalized: Hadith = {
+    id: hadithId,
+    title: input.title?.trim(),
+    narrator: input.narrator?.trim(),
+    source: input.source.trim(),
+    number: input.number?.trim(),
+    text_ar: input.text_ar.trim(),
+    grade: input.grade?.trim(),
+    topic: Array.isArray(input.topic)
+      ? input.topic
+      : input.topic
+        ? [input.topic]
+        : undefined
+  };
+
+  const stored = readStoredJson<Hadith[]>("hadith_custom.json") ?? [];
+  const index = stored.findIndex((item) => item.id === normalized.id);
+
+  if (index >= 0) {
+    stored[index] = normalized;
+  } else {
+    stored.push(normalized);
+  }
+
+  writeStoredJson("hadith_custom.json", stored);
+  return normalized;
 }

--- a/back/src/utils/storage.ts
+++ b/back/src/utils/storage.ts
@@ -1,0 +1,31 @@
+import fs from "fs";
+import path from "path";
+
+const STORAGE_DIR = path.join(process.cwd(), "data", "storage");
+
+function ensureStorageDir() {
+  if (!fs.existsSync(STORAGE_DIR)) {
+    fs.mkdirSync(STORAGE_DIR, { recursive: true });
+  }
+}
+
+export function readStoredJson<T>(fileName: string): T | null {
+  try {
+    const filePath = path.join(STORAGE_DIR, fileName);
+    if (!fs.existsSync(filePath)) {
+      return null;
+    }
+
+    const raw = fs.readFileSync(filePath, "utf-8");
+    return JSON.parse(raw) as T;
+  } catch (error) {
+    console.error(`Failed to read stored json ${fileName}`, error);
+    return null;
+  }
+}
+
+export function writeStoredJson<T>(fileName: string, data: T): void {
+  ensureStorageDir();
+  const filePath = path.join(STORAGE_DIR, fileName);
+  fs.writeFileSync(filePath, JSON.stringify(data, null, 2), "utf-8");
+}


### PR DESCRIPTION
## Summary
- add filesystem-backed storage utilities to retain submitted adhkar and hadith entries
- merge stored items with bundled seed data when serving adhkar and hadith responses
- update POST endpoints to validate input and return the saved records instead of placeholder responses

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f2786086a4832d90a366c06bbef072