### PR TITLE
Add slug-aware Quran routing and navigation

### DIFF
--- a/back/src/routes/quran.ts
+++ b/back/src/routes/quran.ts
@@ -2,8 +2,9 @@ import express from "express";
 
 import { authenticate } from "../middleware/auth.js";
 import { getRecitationTimings, getTafsir } from "../services/dataService.js";
-import type { Recitation } from "../types/index.js";
+import type { Recitation, Surah } from "../types/index.js";
 import { fetchSurahAyat, fetchSurahIndex } from "../services/quranRemoteService.js";
+import { findSurahBySlug } from "../utils/surah.js";
 
 const router = express.Router();
 
@@ -38,26 +39,46 @@ router.get("/tafsir", (_req, res) => {
 });
 
 router.get("/", async (req, res) => {
-  const surahId = Number(req.query.surah) || 1;
+  const rawSurah = Number(req.query.surah);
+  const slugQuery = typeof req.query.slug === "string" ? req.query.slug.trim() : undefined;
 
   try {
-    const [indexResult, ayatResult] = await Promise.all([
-      fetchSurahIndex(),
-      fetchSurahAyat(surahId)
-    ]);
+    const indexResult = await fetchSurahIndex();
+    const surahIndex = indexResult.surahs;
 
-    const surah = indexResult.surahs.find((item) => item.id === surahId) ?? null;
-    const tafsir = getTafsir().filter((entry) => entry.surah_id === surahId);
+    let surah: Surah | undefined;
+    let surahId: number | undefined = Number.isNaN(rawSurah) ? undefined : rawSurah;
+
+    if (slugQuery) {
+      const slugMatch = findSurahBySlug(surahIndex, slugQuery);
+      if (!slugMatch) {
+        return res.status(404).json({ message: "تعذر العثور على السورة المطلوبة بالمعرّف النصي" });
+      }
+      surah = slugMatch;
+      surahId = slugMatch.id;
+    }
+
+    if (!surah && typeof surahId === "number") {
+      surah = surahIndex.find((item) => item.id === surahId);
+    }
 
     if (!surah) {
+      surah = surahIndex.find((item) => item.id === 1) ?? surahIndex[0];
+      surahId = surah?.id;
+    }
+
+    if (!surah || typeof surahId !== "number") {
       return res.status(404).json({ message: "السورة غير موجودة في الفهرس" });
     }
+
+    const tafsirList = getTafsir().filter((entry) => entry.surah_id === surahId);
+    const ayatResult = await fetchSurahAyat(surahId);
 
     if (!ayatResult.ayat.length) {
       return res.status(503).json({
         message: "تعذر تحميل الآيات من المصدر الخارجي ولم تتوافر نسخة محلية لهذه السورة",
         surah,
-        tafsir,
+        tafsir: tafsirList,
         recitations: formatRecitations(surahId),
         cached: true
       });
@@ -71,7 +92,7 @@ router.get("/", async (req, res) => {
     res.json({
       surah,
       ayat: ayatResult.ayat,
-      tafsir,
+      tafsir: tafsirList,
       recitations: formatRecitations(surahId),
       cached: ayatResult.fromCache || indexResult.fromCache,
       message

--- a/back/src/services/dataService.ts
+++ b/back/src/services/dataService.ts
@@ -1,4 +1,5 @@
 import { loadJson } from "../utils/loadData.js";
+import { ensureSurahListSlugs } from "../utils/surah.js";
 import type {
   Ayah,
   DhikrSet,
@@ -11,7 +12,8 @@ import type {
 let recitationTimingsCache: RecitationTimingMap | null = null;
 
 export function getSurahIndex(): Surah[] {
-  return loadJson<Surah[]>("surah_index.json");
+  const surahs = loadJson<Surah[]>("surah_index.json");
+  return ensureSurahListSlugs(surahs);
 }
 
 export function getAyat(): Ayah[] {

--- a/back/src/services/quranRemoteService.ts
+++ b/back/src/services/quranRemoteService.ts
@@ -1,4 +1,5 @@
 import type { Ayah, Surah } from "../types/index.js";
+import { ensureSurahListSlugs } from "../utils/surah.js";
 import { getAyat, getSurahIndex } from "./dataService.js";
 
 const API_BASE = "https://api.alquran.cloud/v1";
@@ -40,11 +41,12 @@ export async function fetchSurahIndex(): Promise<{ surahs: Surah[]; fromCache: b
     if (!surahs.length) {
       throw new Error("Empty surah list from API");
     }
-    cachedSurahIndex = surahs;
-    return { surahs, fromCache: false };
+    const normalized = ensureSurahListSlugs(surahs);
+    cachedSurahIndex = normalized;
+    return { surahs: normalized, fromCache: false };
   } catch (error) {
     console.error("Remote surah index failed", error);
-    const fallback = getSurahIndex();
+    const fallback = ensureSurahListSlugs(getSurahIndex());
     cachedSurahIndex = fallback;
     return { surahs: fallback, fromCache: true };
   }

--- a/back/src/services/quranRemoteService.ts
+++ b/back/src/services/quranRemoteService.ts
@@ -2,7 +2,8 @@ import type { Ayah, Surah } from "../types/index.js";
 import { ensureSurahListSlugs } from "../utils/surah.js";
 import { getAyat, getSurahIndex } from "./dataService.js";
 
-const API_BASE = "https://api.alquran.cloud/v1";
+const ALQURAN_API_BASE = "https://api.alquran.cloud/v1";
+const QURAN_COM_API_BASE = "https://api.quran.com/api/v4";
 
 let cachedSurahIndex: Surah[] | null = null;
 const cachedAyat = new Map<number, Ayah[]>();
@@ -26,13 +27,59 @@ function mapAyah(surahId: number, item: any): Ayah {
   };
 }
 
+function mapQuranComAyah(surahId: number, item: any): Ayah {
+  const verseKey = typeof item.verse_key === "string" ? item.verse_key : "";
+  const [, versePart] = verseKey.split(":");
+  const ayahNumber = Number(versePart ?? item.verse_number ?? 0);
+
+  const candidates = [
+    item.text_uthmani,
+    item.text_uthmani_simple,
+    item.text_indopak,
+    item.text_madani,
+    item.text_imlaei,
+    item.text_qpc_hafs,
+    item.text
+  ];
+
+  const text = candidates.find((value) => typeof value === "string" && value.trim().length > 0);
+
+  return {
+    surah_id: surahId,
+    ayah_number: ayahNumber,
+    text_ar: typeof text === "string" ? text : "",
+    page: typeof item.page_number === "number" ? item.page_number : undefined,
+    juz: typeof item.juz_number === "number" ? item.juz_number : undefined,
+    hizb: typeof item.hizb_number === "number" ? item.hizb_number : undefined
+  };
+}
+
+async function fetchQuranComAyat(surahId: number): Promise<Ayah[]> {
+  const response = await fetch(`${QURAN_COM_API_BASE}/quran/verses/uthmani?chapter_number=${surahId}`);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch verses from quran.com: ${response.status}`);
+  }
+
+  const payload = await response.json();
+  const rawVerses = Array.isArray(payload?.verses) ? payload.verses : [];
+  const verses = rawVerses
+    .map((item: any) => mapQuranComAyah(surahId, item))
+    .filter((verse: Ayah) => verse.ayah_number > 0 && verse.text_ar.trim().length > 0);
+
+  if (!verses.length) {
+    throw new Error("quran.com did not return any verses");
+  }
+
+  return verses;
+}
+
 export async function fetchSurahIndex(): Promise<{ surahs: Surah[]; fromCache: boolean }> {
   if (cachedSurahIndex) {
     return { surahs: cachedSurahIndex, fromCache: true };
   }
 
   try {
-    const response = await fetch(`${API_BASE}/surah`);
+    const response = await fetch(`${ALQURAN_API_BASE}/surah`);
     if (!response.ok) {
       throw new Error(`Failed to fetch surah index: ${response.status}`);
     }
@@ -58,7 +105,15 @@ export async function fetchSurahAyat(surahId: number): Promise<{ ayat: Ayah[]; f
   }
 
   try {
-    const response = await fetch(`${API_BASE}/surah/${surahId}/ar`);
+    try {
+      const verses = await fetchQuranComAyat(surahId);
+      cachedAyat.set(surahId, verses);
+      return { ayat: verses, fromCache: false };
+    } catch (quranComError) {
+      console.error(`quran.com verses for surah ${surahId} failed`, quranComError);
+    }
+
+    const response = await fetch(`${ALQURAN_API_BASE}/surah/${surahId}/ar`);
     if (!response.ok) {
       throw new Error(`Failed to fetch surah ${surahId}: ${response.status}`);
     }

--- a/back/src/types/index.ts
+++ b/back/src/types/index.ts
@@ -22,6 +22,9 @@ export interface Ayah {
   surah_id: number;
   ayah_number: number;
   text_ar: string;
+  page?: number;
+  juz?: number;
+  hizb?: number;
 }
 
 export interface Tafsir {

--- a/back/src/types/index.ts
+++ b/back/src/types/index.ts
@@ -15,6 +15,7 @@ export interface Surah {
   revelation_place?: "Mecca" | "Medina";
   ayah_count: number;
   bismillah_pre?: boolean;
+  slug?: string;
 }
 
 export interface Ayah {

--- a/back/src/utils/slug.ts
+++ b/back/src/utils/slug.ts
@@ -1,0 +1,40 @@
+export const slugify = (value: string | number | undefined | null): string => {
+  if (value === undefined || value === null) {
+    return "";
+  }
+  const stringValue = String(value);
+  if (!stringValue.trim()) {
+    return "";
+  }
+
+  const normalized = stringValue
+    .normalize("NFKD")
+    .replace(/['’`´]/g, "")
+    .replace(/&/g, " and ")
+    .replace(/[\u0300-\u036f]/g, "");
+
+  return normalized
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+};
+
+export const slugMatches = (candidate: string, query: string): boolean => {
+  const normalizedCandidate = slugify(candidate);
+  const normalizedQuery = slugify(query);
+  if (!normalizedCandidate || !normalizedQuery) {
+    return false;
+  }
+  if (normalizedCandidate === normalizedQuery) {
+    return true;
+  }
+
+  const candidateCollapsed = normalizedCandidate.replace(/-/g, "");
+  const queryCollapsed = normalizedQuery.replace(/-/g, "");
+  return (
+    candidateCollapsed === normalizedQuery ||
+    candidateCollapsed === queryCollapsed ||
+    normalizedCandidate === queryCollapsed
+  );
+};

--- a/back/src/utils/surah.ts
+++ b/back/src/utils/surah.ts
@@ -1,0 +1,32 @@
+import type { Surah } from "../types/index.js";
+import { slugMatches, slugify } from "./slug.js";
+
+export const ensureSurahSlug = (surah: Surah): Surah => {
+  const existingSlug = surah.slug?.trim();
+  if (existingSlug) {
+    const normalizedExisting = slugify(existingSlug);
+    if (normalizedExisting === existingSlug) {
+      return surah;
+    }
+    return { ...surah, slug: normalizedExisting };
+  }
+
+  const computed = slugify(surah.name_en ?? surah.name_ar ?? surah.id);
+  if (!computed) {
+    return surah;
+  }
+  return { ...surah, slug: computed };
+};
+
+export const ensureSurahListSlugs = (surahs: Surah[]): Surah[] =>
+  surahs.map((surah) => ensureSurahSlug(surah));
+
+export const findSurahBySlug = (surahs: Surah[], slug: string): Surah | undefined => {
+  if (!slug.trim()) {
+    return undefined;
+  }
+  return surahs.find((surah) => {
+    const candidate = surah.slug ?? surah.name_en ?? surah.name_ar ?? "";
+    return slugMatches(candidate, slug);
+  });
+};

--- a/front/src/components/AudioBar.tsx
+++ b/front/src/components/AudioBar.tsx
@@ -12,6 +12,8 @@ export interface AudioProgressPayload {
 interface AudioBarProps {
   recitations: Recitation[];
   onProgress?: (payload: AudioProgressPayload) => void;
+  variant?: "floating" | "embedded";
+  className?: string;
 }
 
 const findAyahAtTime = (timings: AyahTiming[] | undefined, time: number): number | undefined => {
@@ -33,7 +35,7 @@ const findAyahAtTime = (timings: AyahTiming[] | undefined, time: number): number
   return timings[0]?.ayah_number;
 };
 
-function AudioBar({ recitations, onProgress }: AudioBarProps) {
+function AudioBar({ recitations, onProgress, variant = "floating", className }: AudioBarProps) {
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const [current, setCurrent] = useState(0);
   const [isPlaying, setIsPlaying] = useState(false);
@@ -110,8 +112,18 @@ function AudioBar({ recitations, onProgress }: AudioBarProps) {
 
   if (!track) return null;
 
+  const containerBase =
+    variant === "floating"
+      ? "rounded-3xl border border-primary-light/40 bg-primary-dark/85 p-4 text-xs shadow-[0_18px_45px_rgba(4,20,16,0.45)]"
+      : "rounded-2xl border border-primary-light/15 bg-primary-dark/60 p-4 text-xs";
+  const floatingLayout =
+    "fixed bottom-6 left-1/2 z-40 w-[min(90%,420px)] -translate-x-1/2 sm:left-auto sm:right-8 sm:translate-x-0";
+  const embeddedLayout = "w-full";
+  const layoutClass = variant === "floating" ? floatingLayout : embeddedLayout;
+  const containerClass = [containerBase, layoutClass, className].filter(Boolean).join(" ");
+
   return (
-    <div className="fixed bottom-6 left-1/2 z-40 w-[min(90%,420px)] -translate-x-1/2 rounded-3xl border border-primary-light/40 bg-primary-dark/85 p-4 text-xs shadow-[0_18px_45px_rgba(4,20,16,0.45)] sm:left-auto sm:right-8 sm:translate-x-0">
+    <div className={containerClass}>
       <audio ref={audioRef} src={track.url} preload="metadata" />
       <div className="flex items-center gap-3">
         <button className="btn btn-sm btn-accent" onClick={() => setIsPlaying((prev) => !prev)}>

--- a/front/src/components/HiddenToolbar.tsx
+++ b/front/src/components/HiddenToolbar.tsx
@@ -1,95 +1,218 @@
-import { motion, AnimatePresence } from "framer-motion";
-import type { Surah } from "../types/quran";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { ArrowDownToLine, ArrowUpRight, BookMarked, ChevronDown, ChevronUp, RefreshCcw, Search } from "lucide-react";
+import AudioBar, { type AudioProgressPayload } from "./AudioBar";
+import type { Recitation, Surah } from "../types/quran";
 
 interface ToolbarProps {
-  visible: boolean;
+  open: boolean;
   surahList: Surah[];
   currentSurah?: Surah;
+  recitations: Recitation[];
+  onToggle: () => void;
   onToggleMode: () => void;
   onSelectSurah: (surahId: number) => void;
   onPrev: () => void;
   onNext: () => void;
   onFontChange: (delta: number) => void;
-  onToggleAudio: () => void;
   onShowTafsir: () => void;
   onResetFont?: () => void;
+  onAudioProgress?: (payload: AudioProgressPayload) => void;
+  shouldFocusSearch?: boolean;
+  onSearchFocusHandled?: () => void;
 }
 
 function HiddenToolbar({
-  visible,
+  open,
   surahList,
   currentSurah,
+  recitations,
+  onToggle,
   onToggleMode,
   onSelectSurah,
   onPrev,
   onNext,
   onFontChange,
-  onToggleAudio,
   onShowTafsir,
-  onResetFont
+  onResetFont,
+  onAudioProgress,
+  shouldFocusSearch,
+  onSearchFocusHandled
 }: ToolbarProps) {
+  const [searchTerm, setSearchTerm] = useState("");
+  const searchRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      setSearchTerm("");
+      return;
+    }
+    if (shouldFocusSearch) {
+      const timeout = setTimeout(() => {
+        searchRef.current?.focus();
+        onSearchFocusHandled?.();
+      }, 120);
+      return () => clearTimeout(timeout);
+    }
+    return undefined;
+  }, [open, shouldFocusSearch, onSearchFocusHandled]);
+
+  const filteredSurahs = useMemo(() => {
+    if (!searchTerm.trim()) return surahList;
+    const term = searchTerm.trim();
+    return surahList.filter((surah) => {
+      const arabicMatch = surah.name_ar.includes(term);
+      const englishMatch = surah.name_en?.toLowerCase().includes(term.toLowerCase());
+      const transliterationMatch = surah.slug?.toLowerCase().includes(term.toLowerCase());
+      return arabicMatch || englishMatch || transliterationMatch;
+    });
+  }, [searchTerm, surahList]);
+
   return (
-    <AnimatePresence>
-      {visible && (
-        <motion.div
-          initial={{ y: 120, opacity: 0 }}
-          animate={{ y: 0, opacity: 1 }}
-          exit={{ y: 120, opacity: 0 }}
-          transition={{ type: "spring", damping: 18 }}
-          className="fixed bottom-0 inset-x-0 z-40"
-        >
-          <div className="mx-auto max-w-5xl rounded-t-3xl bg-primary-dark/90 backdrop-blur border border-primary-light/40 shadow-2xl p-4 flex flex-wrap gap-3 items-center justify-center text-sm">
-            <button className="btn btn-sm" onClick={onPrev}>
-              السورة السابقة
-            </button>
-            <button className="btn btn-sm" onClick={onNext}>
-              السورة التالية
-            </button>
-            <label className="form-control w-48">
-              <div className="label">
-                <span className="label-text text-xs">انتقال سريع</span>
+    <>
+      <motion.button
+        type="button"
+        onClick={onToggle}
+        className="fixed bottom-6 right-6 z-40 flex h-14 w-14 items-center justify-center rounded-2xl border border-accent/30 bg-accent/90 text-primary-dark shadow-[0_16px_35px_rgba(8,40,28,0.55)] sm:right-8"
+        whileTap={{ scale: 0.94 }}
+        aria-expanded={open}
+        aria-label={open ? "إخفاء شريط الأدوات" : "إظهار شريط الأدوات"}
+      >
+        {open ? <ChevronDown className="h-6 w-6" /> : <ChevronUp className="h-6 w-6" />}
+      </motion.button>
+
+      <AnimatePresence>
+        {open && (
+          <>
+            <motion.div
+              className="fixed inset-0 z-30 bg-black/50"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              onClick={onToggle}
+            />
+            <motion.div
+              className="fixed inset-x-0 bottom-0 z-40"
+              initial={{ y: 320 }}
+              animate={{ y: 0 }}
+              exit={{ y: 360 }}
+              transition={{ type: "spring", damping: 20, stiffness: 180 }}
+            >
+              <div className="mx-auto w-full max-w-3xl rounded-t-[30px] border border-primary-light/30 bg-primary-dark/95 px-5 pb-6 pt-4 text-sm shadow-[0_-22px_55px_rgba(6,26,22,0.65)]">
+                <div className="mb-4 flex items-center justify-between">
+                  <div className="flex items-center gap-3">
+                    <span className="flex h-11 w-11 items-center justify-center rounded-2xl border border-accent/40 bg-accent/15 text-accent">
+                      <BookMarked className="h-5 w-5" />
+                    </span>
+                    <div>
+                      <p className="text-base font-semibold text-accent">{currentSurah?.name_ar ?? "اختر سورة"}</p>
+                      {currentSurah && (
+                        <p className="text-[11px] text-gray-300">
+                          {currentSurah.revelation_place === "Mecca" ? "سورة مكية" : "سورة مدنية"} • عدد الآيات: {currentSurah.ayah_count}
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                  <button className="btn btn-xs" onClick={onToggleMode}>
+                    تبديل العرض
+                  </button>
+                </div>
+
+                <div className="grid gap-4">
+                  <div className="rounded-2xl border border-primary-light/20 bg-primary-dark/60 p-4">
+                    <div className="flex items-center gap-3">
+                      <Search className="h-4 w-4 text-accent" />
+                      <input
+                        ref={searchRef}
+                        type="search"
+                        value={searchTerm}
+                        onChange={(event) => setSearchTerm(event.target.value)}
+                        placeholder="ابحث عن سورة بالاسم أو الرقم"
+                        className="input input-sm flex-1 bg-primary-dark/60 text-right"
+                      />
+                    </div>
+                    <div className="mt-3 max-h-40 overflow-y-auto pr-1 text-right">
+                      {filteredSurahs.map((surah) => (
+                        <button
+                          key={surah.id}
+                          type="button"
+                          onClick={() => onSelectSurah(surah.id)}
+                          className={`flex w-full items-center justify-between rounded-xl px-3 py-2 transition ${
+                            currentSurah?.id === surah.id
+                              ? "bg-accent/20 text-accent"
+                              : "hover:bg-primary-light/10"
+                          }`}
+                        >
+                          <span>{surah.name_ar}</span>
+                          <span className="text-[11px] text-gray-300">{surah.id}</span>
+                        </button>
+                      ))}
+                      {!filteredSurahs.length && (
+                        <p className="py-6 text-center text-xs text-gray-400">لم يتم العثور على نتائج</p>
+                      )}
+                    </div>
+                  </div>
+
+                  <div className="grid gap-3 rounded-2xl border border-primary-light/20 bg-primary-dark/60 p-4 sm:grid-cols-2">
+                    <div className="flex flex-col gap-3">
+                      <p className="text-xs text-gray-300">الانتقال بين السور</p>
+                      <div className="flex gap-2">
+                        <button className="btn btn-sm flex-1" onClick={onPrev}>
+                          السورة السابقة
+                        </button>
+                        <button className="btn btn-sm flex-1" onClick={onNext}>
+                          السورة التالية
+                        </button>
+                      </div>
+                    </div>
+                    <div className="flex flex-col gap-3">
+                      <p className="text-xs text-gray-300">حجم الخط</p>
+                      <div className="flex items-center gap-2">
+                        <button className="btn btn-sm flex-1" onClick={() => onFontChange(-2)}>
+                          <ArrowDownToLine className="h-4 w-4" /> تصغير
+                        </button>
+                        <button className="btn btn-sm flex-1" onClick={() => onFontChange(2)}>
+                          <ArrowUpRight className="h-4 w-4" /> تكبير
+                        </button>
+                      </div>
+                      {onResetFont && (
+                        <button className="btn btn-xs btn-ghost self-start gap-1" onClick={onResetFont}>
+                          <RefreshCcw className="h-3 w-3" /> إعادة الضبط
+                        </button>
+                      )}
+                    </div>
+                  </div>
+
+                  {recitations.length > 0 && (
+                    <div className="rounded-2xl border border-primary-light/20 bg-primary-dark/60 p-4">
+                      <p className="mb-3 text-xs text-gray-300">التلاوات المتاحة</p>
+                      <AudioBar
+                        recitations={recitations}
+                        onProgress={onAudioProgress}
+                        variant="embedded"
+                        className="border-none bg-transparent p-0 shadow-none"
+                      />
+                    </div>
+                  )}
+
+                  <div className="flex flex-wrap items-center justify-between gap-2 rounded-2xl border border-primary-light/20 bg-primary-dark/60 px-4 py-3">
+                    <p className="text-xs text-gray-300">خيارات إضافية</p>
+                    <div className="flex flex-wrap gap-2">
+                      <button className="btn btn-sm" onClick={onShowTafsir}>
+                        إظهار التفسير
+                      </button>
+                      <button className="btn btn-sm btn-outline" onClick={onToggleMode}>
+                        وضع العرض الكلاسيكي
+                      </button>
+                    </div>
+                  </div>
+                </div>
               </div>
-              <select
-                className="select select-sm"
-                value={currentSurah?.id || ""}
-                onChange={(event) => onSelectSurah(Number(event.target.value))}
-              >
-                <option value="" disabled>
-                  اختر سورة
-                </option>
-                {surahList.map((surah) => (
-                  <option key={surah.id} value={surah.id}>
-                    {surah.name_ar}
-                  </option>
-                ))}
-              </select>
-            </label>
-            <div className="join">
-              <button className="btn btn-sm join-item" onClick={() => onFontChange(-2)}>
-                حجم -
-              </button>
-              <button className="btn btn-sm join-item" onClick={() => onFontChange(2)}>
-                حجم +
-              </button>
-            </div>
-            {onResetFont && (
-              <button className="btn btn-sm" onClick={onResetFont}>
-                إعادة الضبط
-              </button>
-            )}
-            <button className="btn btn-sm" onClick={onToggleAudio}>
-              تشغيل / إيقاف التلاوة
-            </button>
-            <button className="btn btn-sm btn-accent" onClick={onShowTafsir}>
-              إظهار التفسير
-            </button>
-            <button className="btn btn-sm btn-outline" onClick={onToggleMode}>
-              تبديل العرض
-            </button>
-          </div>
-        </motion.div>
-      )}
-    </AnimatePresence>
+            </motion.div>
+          </>
+        )}
+      </AnimatePresence>
+    </>
   );
 }
 

--- a/front/src/components/QuranCanvas.tsx
+++ b/front/src/components/QuranCanvas.tsx
@@ -5,28 +5,12 @@ type Props = {
   surah?: Surah;
   ayat: Ayah[];
   activeAyah?: number;
-  onSelectAyah?: (ayah: Ayah) => void;
+  onSelectAyah?: (ayah: Ayah, rect: DOMRect | null) => void;
   onSwipe?: (direction: "next" | "prev") => void;
   fontSize?: number;
 };
 
 const BISMILLAH_TEXT = "بِسْمِ اللَّهِ الرَّحْمَٰنِ الرَّحِيمِ";
-
-const chunkAyat = (items: Ayah[], size: number) => {
-  const result: Ayah[][] = [];
-  let buffer: Ayah[] = [];
-  items.forEach((item) => {
-    buffer.push(item);
-    if (buffer.length === size) {
-      result.push(buffer);
-      buffer = [];
-    }
-  });
-  if (buffer.length) {
-    result.push(buffer);
-  }
-  return result;
-};
 
 function QuranCanvas({ surah, ayat, activeAyah, onSelectAyah, onSwipe, fontSize }: Props) {
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -41,12 +25,6 @@ function QuranCanvas({ surah, ayat, activeAyah, onSelectAyah, onSwipe, fontSize 
     return firstAyahText !== normalizedBismillah;
   }, [surah, ayat]);
 
-  const ayahGroups = useMemo(() => {
-    if (ayat.length <= 9) return chunkAyat(ayat, 3);
-    if (ayat.length <= 18) return chunkAyat(ayat, 4);
-    return chunkAyat(ayat, 5);
-  }, [ayat]);
-
   useEffect(() => {
     const element = containerRef.current;
     if (!element || !onSwipe) return;
@@ -58,7 +36,8 @@ function QuranCanvas({ surah, ayat, activeAyah, onSelectAyah, onSwipe, fontSize 
     const handlePointerUp = (event: PointerEvent) => {
       if (!pointer.current) return;
       const diffX = event.clientX - pointer.current.x;
-      if (Math.abs(diffX) > 80) {
+      const diffY = event.clientY - pointer.current.y;
+      if (Math.abs(diffX) > Math.abs(diffY) && Math.abs(diffX) > 80) {
         onSwipe(diffX < 0 ? "next" : "prev");
       }
       pointer.current = null;
@@ -75,43 +54,41 @@ function QuranCanvas({ surah, ayat, activeAyah, onSelectAyah, onSwipe, fontSize 
 
   return (
     <div ref={containerRef} className="relative h-full w-full select-none overflow-hidden">
-      <div className="absolute inset-0 bg-[url('https://www.transparenttextures.com/patterns/arabesque.png')] opacity-[0.04]" />
-      <div className="relative flex h-full w-full items-center justify-center px-3 pb-32 pt-20 sm:px-6">
-        <div className="relative w-full max-w-[900px]">
-          <div className="relative mx-auto min-h-[520px] rounded-[42px] border border-primary-light/30 bg-primary-dark/60 p-6 shadow-[0_20px_60px_rgba(6,30,24,0.45)]">
-            <div className="pointer-events-none absolute inset-4 rounded-[34px] border border-primary-light/20" />
+      <div className="absolute inset-0 bg-[url('https://www.transparenttextures.com/patterns/arabesque.png')] opacity-[0.05]" />
+      <div className="relative flex h-full w-full flex-col items-center overflow-y-auto px-3 pb-36 pt-8 sm:px-6">
+        <div className="relative w-full max-w-4xl">
+          <div className="relative mx-auto rounded-[40px] border border-primary-light/20 bg-primary-dark/70 p-4 shadow-[0_24px_60px_rgba(6,26,22,0.55)] sm:p-8">
+            <div className="pointer-events-none absolute inset-4 rounded-[30px] border border-primary-light/15" />
             <div
-              className="relative mx-auto flex min-h-[480px] flex-col justify-center gap-6 rounded-[28px] bg-black/20 px-6 py-10 text-[clamp(18px,2.4vw,34px)] leading-[2.4] text-emerald-100 sm:px-12"
+              className="relative rounded-[26px] bg-black/25 px-4 py-10 text-[clamp(20px,5vw,34px)] leading-[2.7] text-emerald-50 sm:px-10"
               style={fontSize ? { fontSize: `${fontSize}px` } : undefined}
             >
               {shouldRenderBismillah && (
-                <p className="mb-2 text-center text-[clamp(22px,2.6vw,38px)] font-semibold text-amber-200">
+                <p className="mb-6 text-center text-[clamp(22px,6vw,36px)] font-semibold text-amber-200">
                   {BISMILLAH_TEXT}
                 </p>
               )}
-              {ayahGroups.map((group, lineIndex) => (
-                <p
-                  key={lineIndex}
-                  className="flex flex-nowrap items-center justify-evenly gap-4 whitespace-nowrap"
-                >
-                  {group.map((ayah) => (
-                    <span
-                      key={`${ayah.surah_id}-${ayah.ayah_number}`}
-                      className={`inline-flex items-center gap-2 rounded-3xl px-4 py-1.5 transition ${
-                        activeAyah === ayah.ayah_number
-                          ? "bg-accent/30 text-accent"
-                          : "hover:bg-primary-light/20"
-                      }`}
-                      onClick={() => onSelectAyah?.(ayah)}
-                    >
-                      <span className="flex h-6 w-6 items-center justify-center rounded-full border border-accent/30 text-[12px] text-accent">
-                        {ayah.ayah_number}
-                      </span>
-                      <span style={{ fontFamily: '"Noto Naskh Arabic", serif' }}>{ayah.text_ar}</span>
+              <div className="flex flex-col gap-6 text-right">
+                {ayat.map((ayah) => (
+                  <button
+                    key={`${ayah.surah_id}-${ayah.ayah_number}`}
+                    type="button"
+                    data-ayah-id={ayah.ayah_number}
+                    className={`w-full rounded-3xl px-4 py-3 transition duration-150 focus:outline-none focus:ring-2 focus:ring-accent/60 ${
+                      activeAyah === ayah.ayah_number ? "bg-accent/15 text-accent" : "hover:bg-primary-light/10"
+                    }`}
+                    onClick={(event) => {
+                      const rect = (event.currentTarget as HTMLElement).getBoundingClientRect();
+                      onSelectAyah?.(ayah, rect ?? null);
+                    }}
+                  >
+                    <span style={{ fontFamily: '"Noto Naskh Arabic", serif' }}>
+                      {ayah.text_ar}
+                      <span className="mx-2 text-[0.6em] text-amber-300">﴿{ayah.ayah_number}﴾</span>
                     </span>
-                  ))}
-                </p>
-              ))}
+                  </button>
+                ))}
+              </div>
             </div>
           </div>
         </div>

--- a/front/src/components/QuranCanvas.tsx
+++ b/front/src/components/QuranCanvas.tsx
@@ -10,11 +10,21 @@ type Props = {
   fontSize?: number;
 };
 
-const BISMILLAH_TEXT = "بِسْمِ اللَّهِ الرَّحْمَٰنِ الرَّحِيمِ";
+const BISMILLAH_TEXT = "بِسْمِ ٱللَّهِ ٱلرَّحْمَـٰنِ ٱلرَّحِيمِ";
+const FONT_STACK = '"UthmanicHafs", "Scheherazade New", "Amiri", "Lateef", serif';
 
 function QuranCanvas({ surah, ayat, activeAyah, onSelectAyah, onSwipe, fontSize }: Props) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const pointer = useRef<{ x: number; y: number } | null>(null);
+
+  const meta = useMemo(() => {
+    const first = ayat[0];
+    return {
+      page: first?.page,
+      juz: first?.juz,
+      hizb: first?.hizb
+    };
+  }, [ayat]);
 
   const shouldRenderBismillah = useMemo(() => {
     if (!surah || surah.id === 9) return false;
@@ -24,6 +34,19 @@ function QuranCanvas({ surah, ayat, activeAyah, onSelectAyah, onSwipe, fontSize 
     const normalizedBismillah = BISMILLAH_TEXT.replace(/\s+/g, "");
     return firstAyahText !== normalizedBismillah;
   }, [surah, ayat]);
+
+  const baseFontSize = fontSize ?? 32;
+  const verseLineStyle = useMemo(() => ({
+    fontSize: `${baseFontSize}px`,
+    lineHeight: baseFontSize >= 36 ? 2 : 2.2,
+    fontFamily: FONT_STACK
+  }), [baseFontSize]);
+
+  const bismillahStyle = useMemo(() => ({
+    fontSize: `${Math.min(baseFontSize + 4, baseFontSize * 1.15)}px`,
+    lineHeight: 2.4,
+    fontFamily: FONT_STACK
+  }), [baseFontSize]);
 
   useEffect(() => {
     const element = containerRef.current;
@@ -52,45 +75,92 @@ function QuranCanvas({ surah, ayat, activeAyah, onSelectAyah, onSwipe, fontSize 
     };
   }, [onSwipe]);
 
+  const scrollToTop = () => {
+    if (containerRef.current) {
+      containerRef.current.scrollTo({ top: 0, behavior: "smooth" });
+    }
+  };
+
   return (
-    <div ref={containerRef} className="relative h-full w-full select-none overflow-hidden">
-      <div className="absolute inset-0 bg-[url('https://www.transparenttextures.com/patterns/arabesque.png')] opacity-[0.05]" />
-      <div className="relative flex h-full w-full flex-col items-center overflow-y-auto px-3 pb-36 pt-8 sm:px-6">
-        <div className="relative w-full max-w-4xl">
-          <div className="relative mx-auto rounded-[40px] border border-primary-light/20 bg-primary-dark/70 p-4 shadow-[0_24px_60px_rgba(6,26,22,0.55)] sm:p-8">
-            <div className="pointer-events-none absolute inset-4 rounded-[30px] border border-primary-light/15" />
-            <div
-              className="relative rounded-[26px] bg-black/25 px-4 py-10 text-[clamp(20px,5vw,34px)] leading-[2.7] text-emerald-50 sm:px-10"
-              style={fontSize ? { fontSize: `${fontSize}px` } : undefined}
-            >
-              {shouldRenderBismillah && (
-                <p className="mb-6 text-center text-[clamp(22px,6vw,36px)] font-semibold text-amber-200">
-                  {BISMILLAH_TEXT}
-                </p>
-              )}
-              <div className="flex flex-col gap-6 text-right">
-                {ayat.map((ayah) => (
+    <div ref={containerRef} className="relative h-full w-full overflow-y-auto px-4 pb-24 pt-8 sm:px-6">
+      <div className="mx-auto w-full max-w-4xl">
+        <div className="relative overflow-hidden rounded-[36px] border border-emerald-900/15 bg-white/95 text-emerald-900 shadow-[0_24px_70px_rgba(15,64,50,0.12)]">
+          <header className="border-b border-emerald-100 px-6 py-6 sm:px-10">
+            <div className="flex flex-wrap items-center justify-between gap-4">
+              <div className="text-sm text-emerald-700/80">
+                <div className="flex flex-wrap justify-end gap-x-4 gap-y-1">
+                  {meta.juz && <span>جزء {meta.juz}</span>}
+                  {meta.hizb && <span>حزب {meta.hizb}</span>}
+                  {meta.page && <span>صفحة {meta.page}</span>}
+                </div>
+                {surah?.revelation_place && (
+                  <p className="mt-1 text-xs text-emerald-700/60">
+                    {surah.revelation_place === "Mecca" ? "سورة مكية" : "سورة مدنية"} • عدد الآيات: {surah.ayah_count}
+                  </p>
+                )}
+              </div>
+              <div className="text-right">
+                <p className="text-lg font-semibold text-emerald-900">{surah?.name_ar ?? ""}</p>
+                {surah?.id && (
+                  <p className="text-xs text-emerald-700/70">رقم السورة: {surah.id}</p>
+                )}
+              </div>
+            </div>
+          </header>
+
+          <div className="px-6 py-10 sm:px-12">
+            {shouldRenderBismillah && (
+              <p className="mb-10 text-center text-emerald-900" style={bismillahStyle}>
+                {BISMILLAH_TEXT}
+              </p>
+            )}
+            <div className="flex flex-col gap-6 text-right">
+              {ayat.map((ayah) => {
+                const isActive = activeAyah === ayah.ayah_number;
+                return (
                   <button
                     key={`${ayah.surah_id}-${ayah.ayah_number}`}
                     type="button"
                     data-ayah-id={ayah.ayah_number}
-                    className={`w-full rounded-3xl px-4 py-3 transition duration-150 focus:outline-none focus:ring-2 focus:ring-accent/60 ${
-                      activeAyah === ayah.ayah_number ? "bg-accent/15 text-accent" : "hover:bg-primary-light/10"
+                    className={`group flex w-full justify-end rounded-[30px] border border-transparent bg-transparent px-4 py-4 text-right transition-all duration-150 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white ${
+                      isActive ? "border-emerald-300 bg-emerald-50 shadow-inner" : "hover:border-emerald-200 hover:bg-emerald-50/60"
                     }`}
                     onClick={(event) => {
                       const rect = (event.currentTarget as HTMLElement).getBoundingClientRect();
                       onSelectAyah?.(ayah, rect ?? null);
                     }}
                   >
-                    <span style={{ fontFamily: '"Noto Naskh Arabic", serif' }}>
-                      {ayah.text_ar}
-                      <span className="mx-2 text-[0.6em] text-amber-300">﴿{ayah.ayah_number}﴾</span>
+                    <span className="flex-1 text-center text-emerald-900" style={verseLineStyle}>
+                      <span className="font-mushaf inline-block whitespace-normal">
+                        {ayah.text_ar}
+                        <span className="ml-3 inline-flex h-10 w-10 items-center justify-center rounded-full border border-emerald-400 bg-white text-base font-semibold text-emerald-700">
+                          {ayah.ayah_number}
+                        </span>
+                      </span>
                     </span>
                   </button>
-                ))}
-              </div>
+                );
+              })}
             </div>
           </div>
+
+          <footer className="border-t border-emerald-100 px-6 py-5 sm:px-10">
+            <div className="flex flex-wrap items-center justify-center gap-3">
+              <button type="button" className="btn btn-sm" onClick={scrollToTop}>
+                بداية السورة
+              </button>
+              {onSwipe && (
+                <>
+                  <button type="button" className="btn btn-sm" onClick={() => onSwipe("prev")}>
+                    السورة السابقة
+                  </button>
+                  <button type="button" className="btn btn-sm" onClick={() => onSwipe("next")}>
+                    السورة التالية
+                  </button>
+                </>
+              )}
+            </div>
+          </footer>
         </div>
       </div>
     </div>

--- a/front/src/hooks/useQuranContent.ts
+++ b/front/src/hooks/useQuranContent.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import api from "../lib/api";
 import type { Ayah, Recitation, Surah, Tafsir } from "../types/quran";
+import { ensureSurahListSlugs, ensureSurahSlug } from "../utils/quran";
 
 type IndexResponse = { surahs: Surah[]; cached?: boolean };
 type SurahResponse = {
@@ -78,7 +79,7 @@ const remoteLoaders: Array<(surahId: number) => Promise<RemoteSurahPayload>> = [
       ayah_count: Number(meta.numberOfAyahs) || ayahs.length,
       bismillah_pre: surahId !== 1 && surahId !== 9
     };
-    return { surah, ayat: ayahs };
+    return { surah: ensureSurahSlug(surah), ayat: ayahs };
   },
   async (surahId) => {
     const [versesResponse, chapterResponse] = await Promise.all([
@@ -121,7 +122,7 @@ const remoteLoaders: Array<(surahId: number) => Promise<RemoteSurahPayload>> = [
       ayah_count: Number(chapter?.verses_count) || verses.length,
       bismillah_pre: surahId !== 1 && surahId !== 9
     };
-    return { surah, ayat: verses };
+    return { surah: ensureSurahSlug(surah), ayat: verses };
   },
   async (surahId) => {
     const padded = String(surahId).padStart(3, "0");
@@ -157,7 +158,7 @@ const remoteLoaders: Array<(surahId: number) => Promise<RemoteSurahPayload>> = [
       ayah_count: Number(meta?.versesCount ?? verses.length ?? fallback?.ayah_count ?? verses.length),
       bismillah_pre: surahId !== 1 && surahId !== 9
     };
-    return { surah, ayat: verses };
+    return { surah: ensureSurahSlug(surah), ayat: verses };
   }
 ];
 
@@ -187,7 +188,7 @@ const getStoredIndex = (): Surah[] | null => {
   if (!raw) return null;
   try {
     const parsed = JSON.parse(raw);
-    if (Array.isArray(parsed)) return parsed as Surah[];
+    if (Array.isArray(parsed)) return ensureSurahListSlugs(parsed as Surah[]);
   } catch (error) {
     console.warn("Failed to parse cached surah index", error);
   }
@@ -196,7 +197,8 @@ const getStoredIndex = (): Surah[] | null => {
 
 const setStoredIndex = (data: Surah[]) => {
   if (typeof window === "undefined") return;
-  window.localStorage.setItem(INDEX_STORAGE_KEY, JSON.stringify(data));
+  const normalized = ensureSurahListSlugs(data);
+  window.localStorage.setItem(INDEX_STORAGE_KEY, JSON.stringify(normalized));
 };
 
 const getSurahStorageKey = (surahId: number) => `quran-surah-${surahId}-v1`;
@@ -208,7 +210,8 @@ const getStoredSurah = (surahId: number): SurahResponse | null => {
   try {
     const parsed = JSON.parse(raw);
     if (parsed && typeof parsed === "object" && Array.isArray(parsed.ayat)) {
-      return parsed as SurahResponse;
+      const surah = parsed.surah ? ensureSurahSlug(parsed.surah as Surah) : undefined;
+      return { ...parsed, surah } as SurahResponse;
     }
   } catch (error) {
     console.warn("Failed to parse cached surah", error);
@@ -218,7 +221,11 @@ const getStoredSurah = (surahId: number): SurahResponse | null => {
 
 const setStoredSurah = (surahId: number, data: SurahResponse) => {
   if (typeof window === "undefined") return;
-  window.localStorage.setItem(getSurahStorageKey(surahId), JSON.stringify(data));
+  const normalized: SurahResponse = {
+    ...data,
+    surah: data.surah ? ensureSurahSlug(data.surah) : data.surah
+  };
+  window.localStorage.setItem(getSurahStorageKey(surahId), JSON.stringify(normalized));
 };
 
 export function useSurahIndex() {
@@ -232,9 +239,10 @@ export function useSurahIndex() {
     setError(null);
     try {
       const response = await api.get<IndexResponse>("/quran/index");
-      setSurahs(response.data.surahs);
+      const normalized = ensureSurahListSlugs(response.data.surahs);
+      setSurahs(normalized);
       setFromCache(Boolean(response.data.cached));
-      setStoredIndex(response.data.surahs);
+      setStoredIndex(normalized);
     } catch (err) {
       console.error(err);
       setError("تعذر تحميل فهرس السور، تحقق من الاتصال بالإنترنت.");
@@ -266,7 +274,11 @@ export function useQuranSurah(surahId: number) {
       setError(null);
       try {
         const response = await api.get<SurahResponse>("/quran", { params: { surah: id } });
-        if (response.data.ayat.length === 0) {
+        const normalizedResponse: SurahResponse = {
+          ...response.data,
+          surah: response.data.surah ? ensureSurahSlug(response.data.surah) : response.data.surah
+        };
+        if (normalizedResponse.ayat.length === 0) {
           const remote = await fetchRemoteSurah(id);
           if (remote) {
             setData(remote);
@@ -274,15 +286,15 @@ export function useQuranSurah(surahId: number) {
             setError(null);
             return;
           }
-          setError(response.data.message ?? "تعذر تحميل بيانات السورة من المصدر المحلي.");
+          setError(normalizedResponse.message ?? "تعذر تحميل بيانات السورة من المصدر المحلي.");
           const cached = getStoredSurah(id);
           if (cached) {
             setData(cached);
           }
           return;
         }
-        setData(response.data);
-        setStoredSurah(id, response.data);
+        setData(normalizedResponse);
+        setStoredSurah(id, normalizedResponse);
       } catch (err: any) {
         console.error(err);
         const remote = await fetchRemoteSurah(id);

--- a/front/src/hooks/useQuranContent.ts
+++ b/front/src/hooks/useQuranContent.ts
@@ -98,10 +98,22 @@ const remoteLoaders: Array<(surahId: number) => Promise<RemoteSurahPayload>> = [
       ? (versesPayload.verses as any[]).map((item) => {
           const verseKey: string = item.verse_key ?? "";
           const ayahNumber = Number(verseKey.split(":")[1] ?? item.verse_number ?? 0);
+          const candidates = [
+            item.text_uthmani,
+            item.text_uthmani_simple,
+            item.text_indopak,
+            item.text_madani,
+            item.text_imlaei,
+            item.text
+          ];
+          const text = candidates.find((value) => typeof value === "string" && value.trim().length > 0) ?? "";
           return {
             surah_id: surahId,
             ayah_number: ayahNumber,
-            text_ar: String(item.text_uthmani ?? item.text_indopak ?? item.text_madani ?? "")
+            text_ar: String(text),
+            page: typeof item.page_number === "number" ? item.page_number : undefined,
+            juz: typeof item.juz_number === "number" ? item.juz_number : undefined,
+            hizb: typeof item.hizb_number === "number" ? item.hizb_number : undefined
           };
         })
       : [];

--- a/front/src/pages/quran/Classic.tsx
+++ b/front/src/pages/quran/Classic.tsx
@@ -1,25 +1,36 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import type { Ayah } from "../../types/quran";
 import { useQuranSurah, useSurahIndex } from "../../hooks/useQuranContent";
-
-function useQuery() {
-  return new URLSearchParams(useLocation().search);
-}
+import { findSurahBySlug } from "../../utils/quran";
 
 function QuranClassicPage() {
-  const query = useQuery();
+  const location = useLocation();
+  const query = useMemo(() => new URLSearchParams(location.search), [location.search]);
   const navigate = useNavigate();
-  const initialId = Number(query.get("surah")) || 1;
+  const surahParam = query.get("surah");
+  const slugParam = query.get("slug") ?? undefined;
+  const parsedSurahId = surahParam ? Number(surahParam) : NaN;
+  const hasValidSurahParam = !Number.isNaN(parsedSurahId) && parsedSurahId > 0;
+  const initialId = hasValidSurahParam ? parsedSurahId : 1;
   const [currentSurahId, setCurrentSurahId] = useState(initialId);
   const { surahs } = useSurahIndex();
-  const { data, loading, error, refresh } = useQuranSurah(currentSurahId);
 
   useEffect(() => {
-    if (initialId !== currentSurahId) {
-      setCurrentSurahId(initialId);
+    if (hasValidSurahParam && !Number.isNaN(parsedSurahId) && parsedSurahId !== currentSurahId) {
+      setCurrentSurahId(parsedSurahId);
     }
-  }, [initialId, currentSurahId]);
+  }, [hasValidSurahParam, parsedSurahId, currentSurahId]);
+
+  useEffect(() => {
+    if (hasValidSurahParam || !slugParam || !surahs.length) {
+      return;
+    }
+    const match = findSurahBySlug(surahs, slugParam);
+    if (match && match.id !== currentSurahId) {
+      setCurrentSurahId(match.id);
+    }
+  }, [hasValidSurahParam, slugParam, surahs, currentSurahId]);
 
   const surahExists = surahs.some((item) => item.id === currentSurahId);
 
@@ -28,6 +39,31 @@ function QuranClassicPage() {
       setCurrentSurahId(surahs[0].id);
     }
   }, [surahs, surahExists]);
+
+  const buildQueryForSurah = useCallback(
+    (id: number) => {
+      const params = new URLSearchParams();
+      params.set("surah", String(id));
+      const info = surahs.find((item) => item.id === id);
+      if (info?.slug) {
+        params.set("slug", info.slug);
+      }
+      return `?${params.toString()}`;
+    },
+    [surahs]
+  );
+
+  useEffect(() => {
+    if (!surahs.length) {
+      return;
+    }
+    const expected = buildQueryForSurah(currentSurahId);
+    if (expected !== location.search) {
+      navigate(expected, { replace: true });
+    }
+  }, [surahs, currentSurahId, buildQueryForSurah, location.search, navigate]);
+
+  const { data, loading, error, refresh } = useQuranSurah(currentSurahId);
 
   const ayat: Ayah[] = data?.ayat ?? [];
   const surah = data?.surah;
@@ -73,7 +109,7 @@ function QuranClassicPage() {
         <div className="mt-10 flex flex-wrap justify-between gap-3">
           <button
             className="rounded border border-gray-400 px-4 py-2"
-            onClick={() => navigate(`/quran/modern?surah=${currentSurahId}`)}
+            onClick={() => navigate(`/quran/modern${buildQueryForSurah(currentSurahId)}`)}
           >
             العودة للوضع الحديث
           </button>

--- a/front/src/pages/quran/Modern.tsx
+++ b/front/src/pages/quran/Modern.tsx
@@ -4,9 +4,8 @@ import QuranCanvas from "../../components/QuranCanvas";
 import HiddenToolbar from "../../components/HiddenToolbar";
 import TopBar from "../../components/TopBar";
 import TafsirPopover from "../../components/TafsirPopover";
-import AudioBar, { type AudioProgressPayload } from "../../components/AudioBar";
+import type { AudioProgressPayload } from "../../components/AudioBar";
 import type { Ayah, Surah, Tafsir } from "../../types/quran";
-import { useAutoHide } from "../../hooks/useAutoHide";
 import { useQuranSurah, useSurahIndex } from "../../hooks/useQuranContent";
 import { findSurahBySlug } from "../../utils/quran";
 
@@ -14,7 +13,6 @@ function QuranModernPage() {
   const location = useLocation();
   const query = useMemo(() => new URLSearchParams(location.search), [location.search]);
   const navigate = useNavigate();
-  const { visible, show, setVisible } = useAutoHide();
   const surahParam = query.get("surah");
   const slugParam = query.get("slug") ?? undefined;
   const parsedSurahId = surahParam ? Number(surahParam) : NaN;
@@ -23,6 +21,8 @@ function QuranModernPage() {
   const [currentSurahId, setCurrentSurahId] = useState<number>(initialSurahId);
   const [activeAyah, setActiveAyah] = useState<number | undefined>();
   const [anchorRect, setAnchorRect] = useState<DOMRect | null>(null);
+  const [controlsOpen, setControlsOpen] = useState(false);
+  const [pendingSearchFocus, setPendingSearchFocus] = useState(false);
   const activeReciterRef = useRef<string | null>(null);
 
   const computeAutoFont = () => {
@@ -115,19 +115,19 @@ function QuranModernPage() {
 
   useEffect(() => {
     const listener = (event: KeyboardEvent) => {
-      if (event.key.toLowerCase() === "t") {
-        setVisible((prev) => !prev);
-      }
       if (event.key === "ArrowRight") {
         goNext();
       }
       if (event.key === "ArrowLeft") {
         goPrev();
       }
+      if (event.key.toLowerCase() === "b") {
+        setControlsOpen((prev) => !prev);
+      }
     };
     window.addEventListener("keydown", listener);
     return () => window.removeEventListener("keydown", listener);
-  }, [goNext, goPrev, setVisible]);
+  }, [goNext, goPrev]);
 
   useEffect(() => {
     localStorage.setItem("last-reading", JSON.stringify({ surah: currentSurahId, ayah: activeAyah }));
@@ -176,14 +176,48 @@ function QuranModernPage() {
     [ayahNumbers]
   );
 
+  const handleToggleControls = () => setControlsOpen((prev) => !prev);
+
+  const handleShowTafsir = () => {
+    if (!activeAyah && ayat[0]) {
+      const fallbackAyah = ayat[0];
+      setActiveAyah(fallbackAyah.ayah_number);
+      const element = document.querySelector<HTMLElement>(`[data-ayah-id="${fallbackAyah.ayah_number}"]`);
+      if (element) {
+        setAnchorRect(element.getBoundingClientRect());
+        element.scrollIntoView({ behavior: "smooth", block: "center" });
+      }
+    }
+
+    if (activeAyah && !anchorRect) {
+      const element = document.querySelector<HTMLElement>(`[data-ayah-id="${activeAyah}"]`);
+      if (element) {
+        setAnchorRect(element.getBoundingClientRect());
+        element.scrollIntoView({ behavior: "smooth", block: "center" });
+      }
+    }
+    setControlsOpen(false);
+  };
+
+  const handleSelectAyah = (ayah: Ayah, rect: DOMRect | null) => {
+    setActiveAyah(ayah.ayah_number);
+    setAnchorRect(rect);
+  };
+
   return (
-    <div className="relative flex h-full min-h-[100dvh] w-full flex-col bg-primary-dark text-gray-100" onClick={() => show()}>
+    <div className="relative flex min-h-[100dvh] w-full flex-col bg-primary-dark text-gray-100">
       <TopBar
         surah={surah}
-        onToggleMode={() => navigate(`/quran/classic${buildQueryForSurah(currentSurahId)}`)}
-        onOpenSearch={() => show()}
+        onToggleMode={() => {
+          setControlsOpen(false);
+          navigate(`/quran/classic${buildQueryForSurah(currentSurahId)}`);
+        }}
+        onOpenSearch={() => {
+          setControlsOpen(true);
+          setPendingSearchFocus(true);
+        }}
       />
-      <div className="flex-1">
+      <div className="flex-1 pt-16">
         {data?.message && (
           <div className="mx-auto my-4 max-w-4xl rounded-2xl border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-center text-xs text-amber-200">
             {data.message}
@@ -205,48 +239,41 @@ function QuranModernPage() {
             surah={surah}
             ayat={ayat}
             activeAyah={activeAyah}
-            onSelectAyah={(ayah) => {
-              setActiveAyah(ayah.ayah_number);
-              try {
-                const selection = window.getSelection();
-                if (selection && selection.rangeCount > 0) {
-                  const rect = selection.getRangeAt(0).getBoundingClientRect();
-                  setAnchorRect(rect ?? null);
-                } else {
-                  setAnchorRect(null);
-                }
-              } catch (err) {
-                console.warn("Failed to read selection", err);
-                setAnchorRect(null);
-              }
-              show();
-            }}
+            onSelectAyah={handleSelectAyah}
             onSwipe={(direction) => (direction === "next" ? goNext() : goPrev())}
             fontSize={fontSize}
           />
         )}
       </div>
-      {recitations.length > 0 && (
-        <AudioBar
-          recitations={recitations.map((recitation) => ({ ...recitation, surah_id: currentSurahId }))}
-          onProgress={handleAudioProgress}
-        />
-      )}
       <HiddenToolbar
-        visible={visible}
+        open={controlsOpen}
+        onToggle={handleToggleControls}
         surahList={surahs}
         currentSurah={surah}
-        onToggleMode={() => navigate(`/quran/classic${buildQueryForSurah(currentSurahId)}`)}
+        recitations={recitations.map((recitation) => ({ ...recitation, surah_id: currentSurahId }))}
+        onToggleMode={() => {
+          setControlsOpen(false);
+          navigate(`/quran/classic${buildQueryForSurah(currentSurahId)}`);
+        }}
         onSelectSurah={(id) => {
           setCurrentSurahId(id);
           navigate(buildQueryForSurah(id));
+          setControlsOpen(false);
         }}
-        onPrev={goPrev}
-        onNext={goNext}
+        onPrev={() => {
+          goPrev();
+          setControlsOpen(false);
+        }}
+        onNext={() => {
+          goNext();
+          setControlsOpen(false);
+        }}
         onFontChange={handleFontChange}
-        onToggleAudio={() => show()}
-        onShowTafsir={() => show()}
+        onShowTafsir={handleShowTafsir}
         onResetFont={resetFont}
+        onAudioProgress={handleAudioProgress}
+        shouldFocusSearch={pendingSearchFocus}
+        onSearchFocusHandled={() => setPendingSearchFocus(false)}
       />
       <TafsirPopover tafsir={tafsir} anchorRect={anchorRect} onClose={() => setActiveAyah(undefined)} />
       {!loadingIndex && !surahs.length && (

--- a/front/src/pages/quran/Modern.tsx
+++ b/front/src/pages/quran/Modern.tsx
@@ -8,16 +8,19 @@ import AudioBar, { type AudioProgressPayload } from "../../components/AudioBar";
 import type { Ayah, Surah, Tafsir } from "../../types/quran";
 import { useAutoHide } from "../../hooks/useAutoHide";
 import { useQuranSurah, useSurahIndex } from "../../hooks/useQuranContent";
-
-function useQuery() {
-  return new URLSearchParams(useLocation().search);
-}
+import { findSurahBySlug } from "../../utils/quran";
 
 function QuranModernPage() {
-  const query = useQuery();
+  const location = useLocation();
+  const query = useMemo(() => new URLSearchParams(location.search), [location.search]);
   const navigate = useNavigate();
   const { visible, show, setVisible } = useAutoHide();
-  const [currentSurahId, setCurrentSurahId] = useState<number>(Number(query.get("surah")) || 1);
+  const surahParam = query.get("surah");
+  const slugParam = query.get("slug") ?? undefined;
+  const parsedSurahId = surahParam ? Number(surahParam) : NaN;
+  const hasValidSurahParam = !Number.isNaN(parsedSurahId) && parsedSurahId > 0;
+  const initialSurahId = hasValidSurahParam ? parsedSurahId : 1;
+  const [currentSurahId, setCurrentSurahId] = useState<number>(initialSurahId);
   const [activeAyah, setActiveAyah] = useState<number | undefined>();
   const [anchorRect, setAnchorRect] = useState<DOMRect | null>(null);
   const activeReciterRef = useRef<string | null>(null);
@@ -37,6 +40,46 @@ function QuranModernPage() {
   const [isAutoFont, setIsAutoFont] = useState(true);
 
   const { surahs, loading: loadingIndex } = useSurahIndex();
+
+  useEffect(() => {
+    if (hasValidSurahParam && !Number.isNaN(parsedSurahId) && parsedSurahId !== currentSurahId) {
+      setCurrentSurahId(parsedSurahId);
+    }
+  }, [hasValidSurahParam, parsedSurahId, currentSurahId]);
+
+  useEffect(() => {
+    if (hasValidSurahParam || !slugParam || !surahs.length) {
+      return;
+    }
+    const match = findSurahBySlug(surahs, slugParam);
+    if (match && match.id !== currentSurahId) {
+      setCurrentSurahId(match.id);
+    }
+  }, [hasValidSurahParam, slugParam, surahs, currentSurahId]);
+
+  const buildQueryForSurah = useCallback(
+    (id: number) => {
+      const params = new URLSearchParams();
+      params.set("surah", String(id));
+      const info = surahs.find((item) => item.id === id);
+      if (info?.slug) {
+        params.set("slug", info.slug);
+      }
+      return `?${params.toString()}`;
+    },
+    [surahs]
+  );
+
+  useEffect(() => {
+    if (!surahs.length) {
+      return;
+    }
+    const expected = buildQueryForSurah(currentSurahId);
+    if (expected !== location.search) {
+      navigate(expected, { replace: true });
+    }
+  }, [surahs, currentSurahId, buildQueryForSurah, location.search, navigate]);
+
   const { data, loading, error, refresh } = useQuranSurah(currentSurahId);
 
   const surah: Surah | undefined = data?.surah;
@@ -56,7 +99,7 @@ function QuranModernPage() {
     if (index > 0) {
       const target = surahs[index - 1].id;
       setCurrentSurahId(target);
-      navigate(`?surah=${target}`);
+      navigate(buildQueryForSurah(target));
     }
   };
 
@@ -66,7 +109,7 @@ function QuranModernPage() {
     if (index >= 0 && index < surahs.length - 1) {
       const target = surahs[index + 1].id;
       setCurrentSurahId(target);
-      navigate(`?surah=${target}`);
+      navigate(buildQueryForSurah(target));
     }
   };
 
@@ -137,7 +180,7 @@ function QuranModernPage() {
     <div className="relative flex h-full min-h-[100dvh] w-full flex-col bg-primary-dark text-gray-100" onClick={() => show()}>
       <TopBar
         surah={surah}
-        onToggleMode={() => navigate(`/quran/classic?surah=${currentSurahId}`)}
+        onToggleMode={() => navigate(`/quran/classic${buildQueryForSurah(currentSurahId)}`)}
         onOpenSearch={() => show()}
       />
       <div className="flex-1">
@@ -193,10 +236,10 @@ function QuranModernPage() {
         visible={visible}
         surahList={surahs}
         currentSurah={surah}
-        onToggleMode={() => navigate(`/quran/classic?surah=${currentSurahId}`)}
+        onToggleMode={() => navigate(`/quran/classic${buildQueryForSurah(currentSurahId)}`)}
         onSelectSurah={(id) => {
           setCurrentSurahId(id);
-          navigate(`?surah=${id}`);
+          navigate(buildQueryForSurah(id));
         }}
         onPrev={goPrev}
         onNext={goNext}

--- a/front/src/pages/quran/index.tsx
+++ b/front/src/pages/quran/index.tsx
@@ -42,7 +42,15 @@ function QuranIndexPage() {
           {surahs.length > 0 ? (
             <SurahNavigator
               surahList={surahs}
-              onSelect={(id) => window.open(`/quran/modern?surah=${id}`, "_self")}
+              onSelect={(id) => {
+                const params = new URLSearchParams();
+                params.set("surah", String(id));
+                const info = surahs.find((item) => item.id === id);
+                if (info?.slug) {
+                  params.set("slug", info.slug);
+                }
+                window.open(`/quran/modern?${params.toString()}`, "_self");
+              }}
             />
           ) : (
             <div className="flex h-full items-center justify-center text-sm text-gray-400">

--- a/front/src/styles/global.css
+++ b/front/src/styles/global.css
@@ -2,6 +2,13 @@
 @tailwind components;
 @tailwind utilities;
 
+@font-face {
+  font-family: "UthmanicHafs";
+  src: url("https://cdn.jsdelivr.net/gh/quran/quran.com-frontend-next/public/fonts/quran/hafs/uthmanic_hafs/UthmanicHafs1Ver18.woff2")
+      format("woff2");
+  font-display: swap;
+}
+
 :root {
   color-scheme: dark;
 }
@@ -35,4 +42,8 @@ a {
 
 #root {
   min-height: 100vh;
+}
+
+.font-mushaf {
+  font-family: "UthmanicHafs", "Scheherazade New", "Amiri", "Lateef", serif;
 }

--- a/front/src/types/quran.ts
+++ b/front/src/types/quran.ts
@@ -5,6 +5,7 @@ export type Surah = {
   revelation_place?: "Mecca" | "Medina";
   ayah_count: number;
   bismillah_pre?: boolean;
+  slug?: string;
 };
 
 export type Ayah = {

--- a/front/src/utils/quran.ts
+++ b/front/src/utils/quran.ts
@@ -1,0 +1,70 @@
+import type { Surah } from "../types/quran";
+
+export const slugify = (value: string | number | undefined | null): string => {
+  if (value === undefined || value === null) {
+    return "";
+  }
+  const stringValue = String(value);
+  if (!stringValue.trim()) {
+    return "";
+  }
+
+  const normalized = stringValue
+    .normalize("NFKD")
+    .replace(/['’`´]/g, "")
+    .replace(/&/g, " and ")
+    .replace(/[\u0300-\u036f]/g, "");
+
+  return normalized
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+};
+
+export const slugMatches = (candidate: string, query: string): boolean => {
+  const normalizedCandidate = slugify(candidate);
+  const normalizedQuery = slugify(query);
+  if (!normalizedCandidate || !normalizedQuery) {
+    return false;
+  }
+  if (normalizedCandidate === normalizedQuery) {
+    return true;
+  }
+  const candidateCollapsed = normalizedCandidate.replace(/-/g, "");
+  const queryCollapsed = normalizedQuery.replace(/-/g, "");
+  return (
+    candidateCollapsed === normalizedQuery ||
+    candidateCollapsed === queryCollapsed ||
+    normalizedCandidate === queryCollapsed
+  );
+};
+
+export const ensureSurahSlug = (surah: Surah): Surah => {
+  const existing = surah.slug?.trim();
+  if (existing) {
+    const normalized = slugify(existing);
+    if (normalized === existing) {
+      return surah;
+    }
+    return { ...surah, slug: normalized };
+  }
+  const computed = slugify(surah.name_en ?? surah.name_ar ?? surah.id);
+  if (!computed) {
+    return surah;
+  }
+  return { ...surah, slug: computed };
+};
+
+export const ensureSurahListSlugs = (surahs: Surah[]): Surah[] =>
+  surahs.map((surah) => ensureSurahSlug(surah));
+
+export const findSurahBySlug = (surahs: Surah[], slug: string): Surah | undefined => {
+  if (!slug.trim()) {
+    return undefined;
+  }
+  return surahs.find((surah) => {
+    const candidate = surah.slug ?? surah.name_en ?? surah.name_ar ?? "";
+    return slugMatches(candidate, slug);
+  });
+};


### PR DESCRIPTION
## Summary
- add shared slug utilities to enrich Quran metadata on the backend and frontend
- allow the Quran API to resolve surahs by slug and return slug data in responses
- update modern/classic Quran readers and the index navigator to preserve slugs in URLs

## Testing
- npm run build (back)
- npm run build (front)


------
https://chatgpt.com/codex/tasks/task_e_68f512e59f04832d94587b77c672d718