### PR TITLE
Improve Quran ayah rendering and resource performance

### DIFF
--- a/front/index.html
+++ b/front/index.html
@@ -4,6 +4,15 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>تطبيق القرآن الكريم التعليمي</title>
+    <link rel="preconnect" href="https://api.quran.com" />
+    <link rel="preconnect" href="https://cdn.islamic.network" crossorigin />
+    <link
+      rel="preload"
+      href="https://cdn.islamic.network/fonts/UthmanicHafs-Regular.woff2"
+      as="font"
+      type="font/woff2"
+      crossorigin
+    />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/front/src/components/AudioBar.tsx
+++ b/front/src/components/AudioBar.tsx
@@ -126,7 +126,11 @@ function AudioBar({ recitations, onProgress, variant = "floating", className }: 
     <div className={containerClass}>
       <audio ref={audioRef} src={track.url} preload="metadata" />
       <div className="flex items-center gap-3">
-        <button className="btn btn-sm btn-accent" onClick={() => setIsPlaying((prev) => !prev)}>
+        <button
+          className="btn btn-sm btn-accent"
+          onClick={() => setIsPlaying((prev) => !prev)}
+          aria-label={isPlaying ? "إيقاف التلاوة مؤقتًا" : "تشغيل التلاوة"}
+        >
           {isPlaying ? <Pause className="h-4 w-4" /> : <Play className="h-4 w-4" />}
         </button>
         <div className="flex-1">
@@ -145,6 +149,7 @@ function AudioBar({ recitations, onProgress, variant = "floating", className }: 
               index === current ? "border-accent/60 bg-accent/20 text-accent" : "border-primary-light/20 bg-primary-dark/60"
             }`}
             onClick={() => setCurrent(index)}
+            aria-label={`اختيار تلاوة ${rec.reciter}`}
           >
             <Radio className="h-3 w-3" /> {rec.reciter}
           </button>

--- a/front/src/components/Ayah.tsx
+++ b/front/src/components/Ayah.tsx
@@ -1,0 +1,127 @@
+import { memo, useCallback, useMemo } from "react";
+import type { KeyboardEvent, MouseEvent } from "react";
+import clsx from "clsx";
+import type { Ayah } from "../types/quran";
+import { buildAyahAudioUrl } from "../utils/quran";
+
+type AyahProps = {
+  ayah: Ayah;
+  variant?: "classic" | "interactive";
+  active?: boolean;
+  fontSize?: number;
+  onSelect?: (ayah: Ayah, rect: DOMRect | null) => void;
+  showAudioButton?: boolean;
+  className?: string;
+  reciterId?: string;
+};
+
+const Ayah = memo(function Ayah({
+  ayah,
+  variant = "classic",
+  active = false,
+  fontSize,
+  onSelect,
+  showAudioButton = true,
+  className,
+  reciterId
+}: AyahProps) {
+  const audioUrl = useMemo(
+    () => buildAyahAudioUrl(ayah.surah_id, ayah.ayah_number, reciterId),
+    [ayah.ayah_number, ayah.surah_id, reciterId]
+  );
+
+  const handlePlayAudio = useCallback(
+    (event: MouseEvent<HTMLButtonElement>) => {
+      event.stopPropagation();
+      const player = new Audio(audioUrl);
+      player.play().catch(() => undefined);
+    },
+    [audioUrl]
+  );
+
+  const handleClick = useCallback(
+    (event: MouseEvent<HTMLDivElement>) => {
+      if (variant !== "interactive" || !onSelect) return;
+      const rect = (event.currentTarget as HTMLElement).getBoundingClientRect();
+      onSelect(ayah, rect ?? null);
+    },
+    [variant, onSelect, ayah]
+  );
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      if (variant !== "interactive" || !onSelect) return;
+      if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        const rect = (event.currentTarget as HTMLElement).getBoundingClientRect();
+        onSelect(ayah, rect ?? null);
+      }
+    },
+    [variant, onSelect, ayah]
+  );
+
+  const textStyle = fontSize ? { fontSize: `${fontSize}px` } : undefined;
+
+  if (variant === "interactive") {
+    return (
+      <div
+        role="button"
+        tabIndex={0}
+        data-ayah-id={ayah.ayah_number}
+        dir="rtl"
+        lang="ar"
+        className={clsx(
+          "ayah-container ayah-container--interactive w-full gap-4 bg-transparent text-right",
+          active && "ayah-container--active",
+          className
+        )}
+        onClick={handleClick}
+        onKeyDown={handleKeyDown}
+        aria-pressed={active}
+      >
+        <div className="flex w-full items-start justify-between gap-4">
+          <span className="ayah-number" aria-hidden="true">
+            {ayah.ayah_number}
+          </span>
+          <span className="ayah-text flex-1" style={textStyle}>
+            {ayah.text_ar}
+          </span>
+        </div>
+        {showAudioButton && (
+          <div className="flex justify-end">
+            <button
+              type="button"
+              onClick={handlePlayAudio}
+              aria-label={`تشغيل التلاوة للآية ${ayah.ayah_number}`}
+              className="rounded-full border border-emerald-300/60 bg-emerald-50/80 px-4 py-1 text-sm text-emerald-700 shadow-sm"
+            >
+              🔊
+            </button>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className={clsx("ayah-container", className)} dir="rtl" lang="ar">
+      <span className="ayah-number" aria-hidden="true">
+        {ayah.ayah_number}
+      </span>
+      <span className="ayah-text" style={textStyle}>
+        {ayah.text_ar}
+      </span>
+      {showAudioButton && (
+        <button
+          type="button"
+          onClick={handlePlayAudio}
+          aria-label={`تشغيل التلاوة للآية ${ayah.ayah_number}`}
+        >
+          🔊
+        </button>
+      )}
+    </div>
+  );
+});
+
+export default Ayah;

--- a/front/src/components/QuranCanvas.tsx
+++ b/front/src/components/QuranCanvas.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef } from "react";
 import type { Ayah, Surah } from "../types/quran";
+import Ayah from "./Ayah";
 
 type Props = {
   surah?: Surah;
@@ -11,7 +12,6 @@ type Props = {
 };
 
 const BISMILLAH_TEXT = "بِسْمِ ٱللَّهِ ٱلرَّحْمَـٰنِ ٱلرَّحِيمِ";
-const FONT_STACK = '"UthmanicHafs", "Scheherazade New", "Amiri", "Lateef", serif';
 
 function QuranCanvas({ surah, ayat, activeAyah, onSelectAyah, onSwipe, fontSize }: Props) {
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -36,16 +36,10 @@ function QuranCanvas({ surah, ayat, activeAyah, onSelectAyah, onSwipe, fontSize 
   }, [surah, ayat]);
 
   const baseFontSize = fontSize ?? 32;
-  const verseLineStyle = useMemo(() => ({
-    fontSize: `${baseFontSize}px`,
-    lineHeight: baseFontSize >= 36 ? 2 : 2.2,
-    fontFamily: FONT_STACK
-  }), [baseFontSize]);
-
   const bismillahStyle = useMemo(() => ({
     fontSize: `${Math.min(baseFontSize + 4, baseFontSize * 1.15)}px`,
     lineHeight: 2.4,
-    fontFamily: FONT_STACK
+    fontFamily: '"UthmanicHafs", "Scheherazade New", "Amiri", "Lateef", serif'
   }), [baseFontSize]);
 
   useEffect(() => {
@@ -115,32 +109,17 @@ function QuranCanvas({ surah, ayat, activeAyah, onSelectAyah, onSwipe, fontSize 
               </p>
             )}
             <div className="flex flex-col gap-6 text-right">
-              {ayat.map((ayah) => {
-                const isActive = activeAyah === ayah.ayah_number;
-                return (
-                  <button
-                    key={`${ayah.surah_id}-${ayah.ayah_number}`}
-                    type="button"
-                    data-ayah-id={ayah.ayah_number}
-                    className={`group flex w-full justify-end rounded-[30px] border border-transparent bg-transparent px-4 py-4 text-right transition-all duration-150 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white ${
-                      isActive ? "border-emerald-300 bg-emerald-50 shadow-inner" : "hover:border-emerald-200 hover:bg-emerald-50/60"
-                    }`}
-                    onClick={(event) => {
-                      const rect = (event.currentTarget as HTMLElement).getBoundingClientRect();
-                      onSelectAyah?.(ayah, rect ?? null);
-                    }}
-                  >
-                    <span className="flex-1 text-center text-emerald-900" style={verseLineStyle}>
-                      <span className="font-mushaf inline-block whitespace-normal">
-                        {ayah.text_ar}
-                        <span className="ml-3 inline-flex h-10 w-10 items-center justify-center rounded-full border border-emerald-400 bg-white text-base font-semibold text-emerald-700">
-                          {ayah.ayah_number}
-                        </span>
-                      </span>
-                    </span>
-                  </button>
-                );
-              })}
+              {ayat.map((ayah) => (
+                <Ayah
+                  key={`${ayah.surah_id}-${ayah.ayah_number}`}
+                  ayah={ayah}
+                  variant="interactive"
+                  active={activeAyah === ayah.ayah_number}
+                  fontSize={baseFontSize}
+                  onSelect={onSelectAyah}
+                  showAudioButton={false}
+                />
+              ))}
             </div>
           </div>
 

--- a/front/src/pages/quran/Classic.tsx
+++ b/front/src/pages/quran/Classic.tsx
@@ -3,6 +3,7 @@ import { useLocation, useNavigate } from "react-router-dom";
 import type { Ayah } from "../../types/quran";
 import { useQuranSurah, useSurahIndex } from "../../hooks/useQuranContent";
 import { findSurahBySlug } from "../../utils/quran";
+import Ayah from "../../components/Ayah";
 
 function QuranClassicPage() {
   const location = useLocation();
@@ -97,14 +98,15 @@ function QuranClassicPage() {
           </div>
         )}
         {!loading && !error && ayat.length > 0 && (
-          <article className="prose prose-lg rtl:text-right">
+          <section
+            className="rounded-3xl border border-emerald-900/15 bg-white/95 p-8 shadow-[0_24px_70px_rgba(15,64,50,0.12)]"
+            dir="rtl"
+            lang="ar"
+          >
             {ayat.map((ayah) => (
-              <p key={ayah.ayah_number} className="text-2xl leading-loose">
-                <span className="align-top rounded-full border border-gray-400 px-2 py-1 text-sm">{ayah.ayah_number}</span>
-                {ayah.text_ar}
-              </p>
+              <Ayah key={ayah.ayah_number} ayah={ayah} variant="classic" className="classic-ayah" />
             ))}
-          </article>
+          </section>
         )}
         <div className="mt-10 flex flex-wrap justify-between gap-3">
           <button

--- a/front/src/pages/quran/Modern.tsx
+++ b/front/src/pages/quran/Modern.tsx
@@ -1,13 +1,14 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Suspense, lazy, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import QuranCanvas from "../../components/QuranCanvas";
 import HiddenToolbar from "../../components/HiddenToolbar";
 import TopBar from "../../components/TopBar";
-import TafsirPopover from "../../components/TafsirPopover";
 import type { AudioProgressPayload } from "../../components/AudioBar";
 import type { Ayah, Surah, Tafsir } from "../../types/quran";
 import { useQuranSurah, useSurahIndex } from "../../hooks/useQuranContent";
 import { findSurahBySlug } from "../../utils/quran";
+
+const TafsirPopover = lazy(() => import("../../components/TafsirPopover"));
 
 function QuranModernPage() {
   const location = useLocation();
@@ -205,7 +206,7 @@ function QuranModernPage() {
   };
 
   return (
-    <div className="relative flex min-h-[100dvh] w-full flex-col bg-primary-dark text-gray-100">
+    <div className="relative flex min-h-[100dvh] w-full flex-col bg-primary-dark text-gray-100" dir="rtl" lang="ar">
       <TopBar
         surah={surah}
         onToggleMode={() => {
@@ -275,7 +276,9 @@ function QuranModernPage() {
         shouldFocusSearch={pendingSearchFocus}
         onSearchFocusHandled={() => setPendingSearchFocus(false)}
       />
-      <TafsirPopover tafsir={tafsir} anchorRect={anchorRect} onClose={() => setActiveAyah(undefined)} />
+      <Suspense fallback={null}>
+        <TafsirPopover tafsir={tafsir} anchorRect={anchorRect} onClose={() => setActiveAyah(undefined)} />
+      </Suspense>
       {!loadingIndex && !surahs.length && (
         <div className="pointer-events-none absolute inset-0 flex items-center justify-center bg-primary-dark/80 text-sm text-red-200">
           تعذر تحميل فهرس السور، يرجى التحقق من الاتصال.

--- a/front/src/styles/global.css
+++ b/front/src/styles/global.css
@@ -4,8 +4,7 @@
 
 @font-face {
   font-family: "UthmanicHafs";
-  src: url("https://cdn.jsdelivr.net/gh/quran/quran.com-frontend-next/public/fonts/quran/hafs/uthmanic_hafs/UthmanicHafs1Ver18.woff2")
-      format("woff2");
+  src: url("https://cdn.islamic.network/fonts/UthmanicHafs-Regular.woff2") format("woff2");
   font-display: swap;
 }
 
@@ -46,4 +45,92 @@ a {
 
 .font-mushaf {
   font-family: "UthmanicHafs", "Scheherazade New", "Amiri", "Lateef", serif;
+}
+
+.ayah-container {
+  display: block;
+  margin: 1.2rem 0;
+  line-height: 2.4;
+  text-align: justify;
+  direction: rtl;
+  font-family: "UthmanicHafs", "Amiri", serif;
+  font-size: clamp(1.35rem, 2.8vw, 1.65rem);
+  color: #ffd966;
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.33);
+}
+
+.ayah-container button {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: inherit;
+  font-size: 1.05em;
+}
+
+.ayah-container button:focus-visible {
+  outline: 2px solid #ffd966;
+  outline-offset: 4px;
+}
+
+.ayah-number {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.9em;
+  height: 1.9em;
+  border-radius: 50%;
+  border: 1px solid #79c08b;
+  margin: 0 0.6em;
+  font-size: 0.95em;
+  background: rgba(9, 21, 18, 0.3);
+}
+
+.ayah-text {
+  display: inline;
+  font-family: "UthmanicHafs", "Scheherazade New", "Amiri", "Lateef", serif;
+}
+
+.classic-ayah {
+  color: #0f3d2e;
+  background: transparent;
+  text-shadow: none;
+}
+
+.classic-ayah .ayah-number {
+  border-color: #0f3d2e;
+  background: rgba(255, 255, 255, 0.85);
+}
+
+.classic-ayah button {
+  color: #0f3d2e;
+}
+
+.ayah-container--interactive {
+  display: flex;
+  flex-direction: column;
+  border-radius: 30px;
+  border: 1px solid transparent;
+  padding: 1.4rem 1.8rem;
+  background: rgba(255, 255, 255, 0.04);
+  transition: border-color 150ms ease, background-color 150ms ease, box-shadow 150ms ease;
+  text-align: justify;
+}
+
+.ayah-container--interactive:hover,
+.ayah-container--interactive:focus-visible {
+  border-color: rgba(124, 200, 157, 0.55);
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.ayah-container--interactive:focus-visible {
+  outline: 2px solid rgba(124, 200, 157, 0.8);
+  outline-offset: 4px;
+}
+
+.ayah-container--interactive.ayah-container--active {
+  border-color: rgba(103, 180, 140, 0.9);
+  background: rgba(245, 249, 247, 0.85);
+  color: #0f3d2e;
+  text-shadow: none;
+  box-shadow: 0 18px 40px rgba(7, 36, 27, 0.18);
 }

--- a/front/src/utils/quran.ts
+++ b/front/src/utils/quran.ts
@@ -68,3 +68,9 @@ export const findSurahBySlug = (surahs: Surah[], slug: string): Surah | undefine
     return slugMatches(candidate, slug);
   });
 };
+
+export const buildAyahAudioUrl = (surahId: number, ayahNumber: number, reciterId = "mahermuaiqly"): string => {
+  const paddedSurah = String(surahId).padStart(3, "0");
+  const paddedAyah = String(ayahNumber).padStart(3, "0");
+  return `https://cdn.islamic.network/quran/audio/128/ar.${reciterId}/${paddedSurah}${paddedAyah}.mp3`;
+};

--- a/front/vercel.json
+++ b/front/vercel.json
@@ -1,0 +1,10 @@
+{
+  "headers": [
+    {
+      "source": "/(.*)\\.(woff2|svg|jpg|png)",
+      "headers": [
+        { "key": "Cache-Control", "value": "public,max-age=31536000,immutable" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- introduce a memoized Ayah component that renders verses with Ottoman font styling, accessible audio controls, and corrected RTL alignment for both classic and modern Quran views
- lazy-load tafsir UI, add audio control aria labels, and configure resource preconnect/preload plus immutable caching headers for static assets
- refresh global Quran typography to use the official Uthmanic font while refining verse number geometry and modern layout states

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f79e6dbc8c832da7eb64cda410be12