### PR TITLE
Fix Quran reader header overlap

### DIFF
--- a/front/src/components/TopBar.tsx
+++ b/front/src/components/TopBar.tsx
@@ -5,31 +5,41 @@ interface Props {
   surah?: Surah;
   onToggleMode: () => void;
   onOpenSearch: () => void;
+  onGoHome: () => void;
+  role: string;
 }
 
-function TopBar({ surah, onToggleMode, onOpenSearch }: Props) {
+function TopBar({ surah, onToggleMode, onOpenSearch, onGoHome, role }: Props) {
   return (
-    <header className="fixed top-0 inset-x-0 h-16 flex items-center justify-between px-6 bg-primary-dark/70 supports-[backdrop-filter]:backdrop-blur z-30 text-sm">
-      <div className="flex items-center gap-3">
-        <span className="flex h-10 w-10 items-center justify-center rounded-2xl border border-accent/30 bg-accent/10 text-accent">
-          <BookMarked className="h-5 w-5" />
-        </span>
-        <div>
-          <p className="text-base font-semibold text-accent">{surah?.name_ar ?? "اختر سورة"}</p>
-          {surah?.revelation_place && (
-            <p className="text-[11px] text-gray-300">
-              {surah.revelation_place === "Mecca" ? "سورة مكية" : "سورة مدنية"} • عدد الآيات: {surah.ayah_count}
-            </p>
-          )}
+    <header className="fixed inset-x-0 top-0 z-30 bg-primary-dark/70 px-4 text-sm supports-[backdrop-filter]:backdrop-blur sm:px-6">
+      <div className="flex min-h-16 w-full flex-wrap items-center justify-between gap-4">
+        <div className="flex min-w-0 items-center gap-3">
+          <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl border border-accent/30 bg-accent/10 text-accent">
+            <BookMarked className="h-5 w-5" />
+          </span>
+          <div className="min-w-0">
+            <p className="truncate text-base font-semibold text-accent">{surah?.name_ar ?? "اختر سورة"}</p>
+            {surah?.revelation_place && (
+              <p className="text-[11px] text-gray-300">
+                {surah.revelation_place === "Mecca" ? "سورة مكية" : "سورة مدنية"} • عدد الآيات: {surah.ayah_count}
+              </p>
+            )}
+          </div>
         </div>
-      </div>
-      <div className="flex items-center gap-2">
-        <button className="btn btn-xs" onClick={onToggleMode}>
-          تبديل العرض
-        </button>
-        <button className="btn btn-xs btn-outline gap-1" onClick={onOpenSearch}>
-          <Search className="h-3 w-3" /> بحث
-        </button>
+        <div className="flex flex-1 flex-wrap items-center justify-end gap-2">
+          <button className="btn btn-xs whitespace-nowrap" onClick={onToggleMode}>
+            تبديل العرض
+          </button>
+          <button className="btn btn-xs btn-outline gap-1 whitespace-nowrap" onClick={onOpenSearch}>
+            <Search className="h-3 w-3" /> بحث
+          </button>
+          <button className="btn btn-xs btn-outline btn-accent whitespace-nowrap" onClick={onGoHome}>
+            رجوع للرئيسية ({role})
+          </button>
+          <span className="order-4 w-full text-center text-[11px] text-gray-300 sm:order-none sm:w-auto sm:text-right">
+            اضغط على حرف T لإظهار الأدوات أو الأسهم للتنقل بين السور
+          </span>
+        </div>
       </div>
     </header>
   );

--- a/front/src/layouts/QuranLayout.tsx
+++ b/front/src/layouts/QuranLayout.tsx
@@ -1,11 +1,7 @@
-import { Outlet, useNavigate } from "react-router-dom";
+import { Outlet } from "react-router-dom";
 import { useEffect } from "react";
-import { useAuthStore } from "../store/auth";
 
 function QuranLayout() {
-  const navigate = useNavigate();
-  const { role } = useAuthStore();
-
   useEffect(() => {
     document.body.classList.add("overflow-hidden");
     return () => {
@@ -16,14 +12,6 @@ function QuranLayout() {
   return (
     <div className="relative min-h-[100dvh] w-full bg-[radial-gradient(circle_at_top,_rgba(18,70,54,0.65),_#020605_70%)] text-white">
       <Outlet />
-      <div className="fixed top-4 right-4 z-50 flex flex-col items-end gap-2 text-xs">
-        <button onClick={() => navigate("/")} className="btn btn-sm btn-outline btn-accent">
-          رجوع للرئيسية ({role})
-        </button>
-        <span className="hidden sm:block rounded-full border border-primary-light/40 bg-primary-dark/70 px-3 py-1 text-[11px] text-gray-200">
-          اضغط على حرف T لإظهار الأدوات أو الأسهم للتنقل بين السور
-        </span>
-      </div>
     </div>
   );
 }

--- a/front/src/pages/quran/Modern.tsx
+++ b/front/src/pages/quran/Modern.tsx
@@ -8,6 +8,7 @@ import type { AudioProgressPayload } from "../../components/AudioBar";
 import type { Ayah, Surah, Tafsir } from "../../types/quran";
 import { useQuranSurah, useSurahIndex } from "../../hooks/useQuranContent";
 import { findSurahBySlug } from "../../utils/quran";
+import { useAuthStore } from "../../store/auth";
 
 function QuranModernPage() {
   const location = useLocation();
@@ -24,6 +25,7 @@ function QuranModernPage() {
   const [controlsOpen, setControlsOpen] = useState(false);
   const [pendingSearchFocus, setPendingSearchFocus] = useState(false);
   const activeReciterRef = useRef<string | null>(null);
+  const { role } = useAuthStore();
 
   const computeAutoFont = () => {
     if (typeof window === "undefined") return 30;
@@ -216,6 +218,8 @@ function QuranModernPage() {
           setControlsOpen(true);
           setPendingSearchFocus(true);
         }}
+        role={role}
+        onGoHome={() => navigate("/")}
       />
       <div className="flex-1 pt-16">
         {data?.message && (


### PR DESCRIPTION
## Summary
- merge the floating controls into the Quran reader top bar to eliminate the header overlap
- tidy the Quran layout by removing the redundant fixed control overlay and wiring navigation through the new top bar props

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f7af0a8c34832db30ff8d40be56d84