### PR TITLE
Add translation reading mode to Quran reader

### DIFF
--- a/front/src/components/QuranTranslationView.tsx
+++ b/front/src/components/QuranTranslationView.tsx
@@ -1,0 +1,118 @@
+import clsx from "clsx";
+import { Fragment, useMemo } from "react";
+import type { Ayah, AyahTranslation } from "../types/quran";
+
+type Props = {
+  ayat: Ayah[];
+  translations: Map<number, AyahTranslation>;
+  loading?: boolean;
+  error?: string | null;
+  onRetry?: () => void;
+  activeAyah?: number;
+  onSelectAyah?: (ayah: Ayah, rect: DOMRect | null) => void;
+};
+
+const decodeTranslation = (text: string): string => {
+  if (!text) return "";
+  if (typeof window !== "undefined" && typeof DOMParser !== "undefined") {
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(text, "text/html");
+    return doc.body.textContent ?? text;
+  }
+  return text.replace(/<[^>]*>/g, "");
+};
+
+function QuranTranslationView({
+  ayat,
+  translations,
+  loading,
+  error,
+  onRetry,
+  activeAyah,
+  onSelectAyah
+}: Props) {
+  const hasTranslations = useMemo(() => translations.size > 0, [translations]);
+
+  if (loading && !hasTranslations) {
+    return (
+      <div className="flex h-full items-center justify-center text-sm text-gray-300">
+        جاري تحميل الترجمة المختارة...
+      </div>
+    );
+  }
+
+  if (!loading && error && !hasTranslations) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-3 text-center text-sm text-red-200">
+        <p>{error}</p>
+        {onRetry && (
+          <button className="btn btn-sm" onClick={onRetry}>
+            إعادة المحاولة
+          </button>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto flex w-full max-w-4xl flex-col gap-4 px-4 pb-32 pt-6 sm:px-8">
+      {loading && hasTranslations && (
+        <div className="rounded-2xl border border-amber-500/20 bg-amber-500/10 px-4 py-2 text-center text-[11px] text-amber-200">
+          يتم تحديث الترجمة في الخلفية...
+        </div>
+      )}
+      {error && hasTranslations && (
+        <div className="rounded-2xl border border-amber-500/20 bg-amber-500/10 px-4 py-2 text-center text-[11px] text-amber-200">
+          {error}
+        </div>
+      )}
+      <div className="flex flex-col gap-4" dir="rtl">
+        {ayat.map((ayah) => {
+          const translation = translations.get(ayah.ayah_number);
+          const segments = translation ? translation.text.split(/\n+/) : [];
+          return (
+            <article
+              key={`${ayah.surah_id}-${ayah.ayah_number}`}
+              className={clsx(
+                "group relative overflow-hidden rounded-3xl border border-primary-light/30 bg-primary-dark/70 p-5 shadow-[0_18px_40px_rgba(6,30,24,0.3)] transition",
+                activeAyah === ayah.ayah_number
+                  ? "border-accent/60 bg-accent/10 shadow-[0_0_35px_rgba(34,197,94,0.35)]"
+                  : "hover:border-accent/40 hover:bg-primary-dark/80"
+              )}
+              onClick={(event) => onSelectAyah?.(ayah, event.currentTarget.getBoundingClientRect())}
+            >
+              <header className="mb-3 flex flex-wrap items-center justify-between gap-3 text-xs text-gray-300">
+                <span className="flex items-center gap-3">
+                  <span className="flex h-8 w-8 items-center justify-center rounded-full border border-accent/30 bg-accent/10 text-sm text-accent">
+                    {ayah.ayah_number}
+                  </span>
+                  <span className="font-semibold text-accent">آية رقم {ayah.ayah_number}</span>
+                </span>
+                {translation?.source && (
+                  <span className="text-[10px] text-gray-400">{translation.source}</span>
+                )}
+              </header>
+              <p className="text-[clamp(18px,2.2vw,32px)] leading-[2.2] text-emerald-100" style={{ fontFamily: '"Noto Naskh Arabic", serif' }}>
+                {ayah.text_ar}
+              </p>
+              <div className="mt-4 rounded-3xl bg-black/30 p-4 text-left text-sm leading-7 text-gray-200" dir="auto">
+                {translation ? (
+                  segments.map((segment, index) => (
+                    <Fragment key={index}>
+                      <span>{decodeTranslation(segment)}</span>
+                      {index < segments.length - 1 && <br />}
+                    </Fragment>
+                  ))
+                ) : (
+                  <span className="text-gray-400">لم تتوفر ترجمة لهذه الآية.</span>
+                )}
+              </div>
+            </article>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export default QuranTranslationView;

--- a/front/src/components/ReadingPreferenceSwitcher.tsx
+++ b/front/src/components/ReadingPreferenceSwitcher.tsx
@@ -1,0 +1,69 @@
+import clsx from "clsx";
+import { BookOpenText, ScrollText } from "lucide-react";
+
+type ViewMode = "reading" | "translation";
+
+interface Props {
+  mode: ViewMode;
+  onChange: (mode: ViewMode) => void;
+  translationSource?: string;
+  translationLoading?: boolean;
+}
+
+function ReadingPreferenceSwitcher({ mode, onChange, translationSource, translationLoading }: Props) {
+  const activeIndex = mode === "translation" ? 0 : 1;
+
+  return (
+    <div className="relative z-20 mx-auto mt-24 w-full max-w-xl px-6">
+      <div className="relative flex h-14 items-center rounded-full border border-primary-light/40 bg-primary-dark/70 p-1 text-sm shadow-[0_14px_40px_rgba(6,30,24,0.35)]">
+        <span
+          aria-hidden
+          className="pointer-events-none absolute inset-y-1 w-1/2 rounded-full bg-accent/20 transition-transform duration-300 ease-out"
+          style={{ transform: `translateX(${activeIndex * 100}%)` }}
+        />
+        <button
+          type="button"
+          className={clsx(
+            "relative z-10 flex flex-1 items-center justify-center gap-2 rounded-full px-4 py-2 font-semibold transition",
+            mode === "translation" ? "text-accent" : "text-gray-300 hover:text-gray-100"
+          )}
+          onClick={() => onChange("translation")}
+          aria-pressed={mode === "translation"}
+        >
+          <BookOpenText className="h-5 w-5" />
+          <span>الترجمة</span>
+          {translationLoading && mode === "translation" && (
+            <span className="text-[10px] text-accent/70">جاري التحميل...</span>
+          )}
+        </button>
+        <button
+          type="button"
+          className={clsx(
+            "relative z-10 flex flex-1 items-center justify-center gap-2 rounded-full px-4 py-2 font-semibold transition",
+            mode === "reading" ? "text-accent" : "text-gray-300 hover:text-gray-100"
+          )}
+          onClick={() => onChange("reading")}
+          aria-pressed={mode === "reading"}
+        >
+          <ScrollText className="h-5 w-5" />
+          <span>القراءة</span>
+        </button>
+      </div>
+      {mode === "translation" && (
+        <div className="mt-2 text-center text-[11px] text-gray-300">
+          {translationLoading && !translationSource ? (
+            <span>جاري تحميل الترجمة المختارة...</span>
+          ) : translationSource ? (
+            <span>
+              الترجمة المعروضة: <span className="text-emerald-200">{translationSource}</span>
+            </span>
+          ) : (
+            <span>يمكنك عرض الترجمة العربية واللغات الأخرى من خلال هذا الوضع.</span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default ReadingPreferenceSwitcher;

--- a/front/src/hooks/useSurahTranslation.ts
+++ b/front/src/hooks/useSurahTranslation.ts
@@ -1,0 +1,117 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { AyahTranslation } from "../types/quran";
+
+type StoredTranslation = {
+  translations: AyahTranslation[];
+  source?: string;
+};
+
+type RemoteTranslationItem = {
+  verse_key?: string;
+  verse_number?: number;
+  text?: string;
+  resource_name?: string;
+};
+
+type RemoteTranslationResponse = {
+  translations?: RemoteTranslationItem[];
+  resource_name?: string;
+};
+
+const getStorageKey = (surahId: number, translatorId: number) => `quran-translation-${translatorId}-${surahId}-v1`;
+
+const getStoredTranslation = (surahId: number, translatorId: number): StoredTranslation | null => {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(getStorageKey(surahId, translatorId));
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === "object" && Array.isArray(parsed.translations)) {
+      return parsed as StoredTranslation;
+    }
+  } catch (error) {
+    console.warn("Failed to parse stored translation", error);
+  }
+  return null;
+};
+
+const setStoredTranslation = (surahId: number, translatorId: number, data: StoredTranslation) => {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(getStorageKey(surahId, translatorId), JSON.stringify(data));
+  } catch (error) {
+    console.warn("Failed to persist translation", error);
+  }
+};
+
+export function useSurahTranslation(surahId: number, translatorId = 131, enabled = true) {
+  const initial = useMemo(() => getStoredTranslation(surahId, translatorId), [surahId, translatorId]);
+  const [translations, setTranslations] = useState<AyahTranslation[]>(initial?.translations ?? []);
+  const [source, setSource] = useState<string | undefined>(initial?.source);
+  const [loading, setLoading] = useState<boolean>(enabled && !initial?.translations?.length);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(
+    async (targetId = surahId) => {
+      if (!enabled) return;
+      setLoading(true);
+      setError(null);
+      try {
+        const response = await fetch(
+          `https://api.quran.com/api/v4/quran/translations/${translatorId}?chapter_number=${targetId}`
+        );
+        if (!response.ok) {
+          throw new Error(`Failed to fetch translation (${response.status})`);
+        }
+        const payload: RemoteTranslationResponse = await response.json();
+        const items: AyahTranslation[] = Array.isArray(payload?.translations)
+          ? payload.translations.map((item) => {
+              const verseKey = String(item.verse_key ?? "");
+              const ayahNumber = Number(verseKey.split(":")[1] ?? item.verse_number ?? 0);
+              return {
+                surah_id: targetId,
+                ayah_number: ayahNumber,
+                text: String(item.text ?? ""),
+                source: item.resource_name ?? payload?.resource_name ?? undefined
+              } satisfies AyahTranslation;
+            })
+          : [];
+        const resourceName: string | undefined = items[0]?.source ?? payload?.resource_name;
+        setTranslations(items);
+        setSource(resourceName);
+        setStoredTranslation(targetId, translatorId, { translations: items, source: resourceName });
+      } catch (err) {
+        console.warn("Failed to fetch surah translation", err);
+        setError("تعذر تحميل الترجمة، يرجى التحقق من الاتصال.");
+      } finally {
+        setLoading(false);
+      }
+    },
+    [enabled, surahId, translatorId]
+  );
+
+  useEffect(() => {
+    if (!enabled) {
+      setLoading(false);
+      return;
+    }
+    const cached = getStoredTranslation(surahId, translatorId);
+    if (cached) {
+      setTranslations(cached.translations);
+      setSource(cached.source);
+      setError(null);
+      if (!cached.translations.length) {
+        load(surahId).catch(() => undefined);
+      } else {
+        setLoading(false);
+      }
+    } else {
+      setTranslations([]);
+      setSource(undefined);
+      setLoading(true);
+      load(surahId).catch(() => undefined);
+    }
+  }, [surahId, translatorId, enabled, load]);
+
+  return { translations, loading, error, refresh: load, source };
+}

--- a/front/src/pages/quran/Modern.tsx
+++ b/front/src/pages/quran/Modern.tsx
@@ -5,19 +5,26 @@ import HiddenToolbar from "../../components/HiddenToolbar";
 import TopBar from "../../components/TopBar";
 import TafsirPopover from "../../components/TafsirPopover";
 import AudioBar, { type AudioProgressPayload } from "../../components/AudioBar";
+import ReadingPreferenceSwitcher from "../../components/ReadingPreferenceSwitcher";
+import QuranTranslationView from "../../components/QuranTranslationView";
 import type { Ayah, Surah, Tafsir } from "../../types/quran";
 import { useAutoHide } from "../../hooks/useAutoHide";
 import { useQuranSurah, useSurahIndex } from "../../hooks/useQuranContent";
+import { useSurahTranslation } from "../../hooks/useSurahTranslation";
 
 function useQuery() {
-  return new URLSearchParams(useLocation().search);
+  const location = useLocation();
+  return useMemo(() => new URLSearchParams(location.search), [location.search]);
 }
+
+type ViewMode = "reading" | "translation";
 
 function QuranModernPage() {
   const query = useQuery();
   const navigate = useNavigate();
   const { visible, show, setVisible } = useAutoHide();
   const [currentSurahId, setCurrentSurahId] = useState<number>(Number(query.get("surah")) || 1);
+  const [viewMode, setViewMode] = useState<ViewMode>(query.get("view") === "translation" ? "translation" : "reading");
   const [activeAyah, setActiveAyah] = useState<number | undefined>();
   const [anchorRect, setAnchorRect] = useState<DOMRect | null>(null);
   const activeReciterRef = useRef<string | null>(null);
@@ -38,37 +45,68 @@ function QuranModernPage() {
 
   const { surahs, loading: loadingIndex } = useSurahIndex();
   const { data, loading, error, refresh } = useQuranSurah(currentSurahId);
+  const {
+    translations,
+    loading: translationsLoading,
+    error: translationsError,
+    source: translationSource,
+    refresh: refreshTranslations
+  } = useSurahTranslation(currentSurahId, 131, viewMode === "translation");
 
   const surah: Surah | undefined = data?.surah;
-  const ayat: Ayah[] = data?.ayat ?? [];
-  const tafsirMap = useMemo(() => new Map<string, Tafsir>(), [data?.tafsir]);
+  const ayat: Ayah[] = useMemo(() => data?.ayat ?? [], [data?.ayat]);
+  const tafsirMap = useMemo(() => {
+    const map = new Map<string, Tafsir>();
+    data?.tafsir?.forEach((item) => {
+      map.set(`${item.surah_id}-${item.ayah_number}`, item);
+    });
+    return map;
+  }, [data?.tafsir]);
   const ayahNumbers = useMemo(() => new Set(ayat.map((item) => item.ayah_number)), [ayat]);
-
-  if (data?.tafsir) {
-    data.tafsir.forEach((item) => tafsirMap.set(`${item.surah_id}-${item.ayah_number}`, item));
-  }
+  const translationMap = useMemo(() => {
+    return new Map(translations.map((item) => [item.ayah_number, item]));
+  }, [translations]);
 
   const tafsir = activeAyah ? tafsirMap.get(`${currentSurahId}-${activeAyah}`) : undefined;
 
-  const goPrev = () => {
+  const buildSearch = useCallback(
+    (surahId: number, mode: ViewMode = viewMode) => {
+      const params = new URLSearchParams();
+      params.set("surah", String(surahId));
+      if (mode === "translation") {
+        params.set("view", "translation");
+      }
+      return `?${params.toString()}`;
+    },
+    [viewMode]
+  );
+
+  const navigateToSurah = useCallback(
+    (surahId: number, mode: ViewMode = viewMode) => {
+      navigate(buildSearch(surahId, mode));
+    },
+    [buildSearch, navigate, viewMode]
+  );
+
+  const goPrev = useCallback(() => {
     if (!surahs.length) return;
     const index = surahs.findIndex((s) => s.id === currentSurahId);
     if (index > 0) {
       const target = surahs[index - 1].id;
       setCurrentSurahId(target);
-      navigate(`?surah=${target}`);
+      navigateToSurah(target);
     }
-  };
+  }, [currentSurahId, navigateToSurah, surahs]);
 
-  const goNext = () => {
+  const goNext = useCallback(() => {
     if (!surahs.length) return;
     const index = surahs.findIndex((s) => s.id === currentSurahId);
     if (index >= 0 && index < surahs.length - 1) {
       const target = surahs[index + 1].id;
       setCurrentSurahId(target);
-      navigate(`?surah=${target}`);
+      navigateToSurah(target);
     }
-  };
+  }, [currentSurahId, navigateToSurah, surahs]);
 
   useEffect(() => {
     const listener = (event: KeyboardEvent) => {
@@ -87,8 +125,11 @@ function QuranModernPage() {
   }, [goNext, goPrev, setVisible]);
 
   useEffect(() => {
-    localStorage.setItem("last-reading", JSON.stringify({ surah: currentSurahId, ayah: activeAyah }));
-  }, [currentSurahId, activeAyah]);
+    localStorage.setItem(
+      "last-reading",
+      JSON.stringify({ surah: currentSurahId, ayah: activeAyah, view: viewMode })
+    );
+  }, [currentSurahId, activeAyah, viewMode]);
 
   useEffect(() => {
     if (!isAutoFont) return;
@@ -133,12 +174,56 @@ function QuranModernPage() {
     [ayahNumbers]
   );
 
+  useEffect(() => {
+    const targetSurah = Number(query.get("surah")) || 1;
+    if (targetSurah !== currentSurahId) {
+      setCurrentSurahId(targetSurah);
+    }
+    const queryView = query.get("view") === "translation" ? "translation" : "reading";
+    if (queryView !== viewMode) {
+      setViewMode(queryView);
+    }
+  }, [query, currentSurahId, viewMode]);
+
+  const handleViewChange = (mode: ViewMode) => {
+    if (mode === viewMode) return;
+    setViewMode(mode);
+    navigate(buildSearch(currentSurahId, mode), { replace: true });
+  };
+
+  const handleAyahSelection = useCallback(
+    (ayah: Ayah, fallbackRect?: DOMRect | null) => {
+      setActiveAyah(ayah.ayah_number);
+      let rect: DOMRect | null = null;
+      try {
+        const selection = window.getSelection();
+        if (selection && selection.rangeCount > 0) {
+          rect = selection.getRangeAt(0).getBoundingClientRect();
+        }
+      } catch (err) {
+        console.warn("Failed to read selection", err);
+      }
+      if (!rect && fallbackRect) {
+        rect = fallbackRect;
+      }
+      setAnchorRect(rect ?? null);
+      show();
+    },
+    [show]
+  );
+
   return (
     <div className="relative flex h-full min-h-[100dvh] w-full flex-col bg-primary-dark text-gray-100" onClick={() => show()}>
       <TopBar
         surah={surah}
         onToggleMode={() => navigate(`/quran/classic?surah=${currentSurahId}`)}
         onOpenSearch={() => show()}
+      />
+      <ReadingPreferenceSwitcher
+        mode={viewMode}
+        onChange={handleViewChange}
+        translationSource={translationSource}
+        translationLoading={translationsLoading}
       />
       <div className="flex-1">
         {data?.message && (
@@ -157,29 +242,25 @@ function QuranModernPage() {
             </button>
           </div>
         )}
-        {!loading && !error && ayat.length > 0 && (
+        {!loading && !error && ayat.length > 0 && viewMode === "reading" && (
           <QuranCanvas
             surah={surah}
             ayat={ayat}
             activeAyah={activeAyah}
-            onSelectAyah={(ayah) => {
-              setActiveAyah(ayah.ayah_number);
-              try {
-                const selection = window.getSelection();
-                if (selection && selection.rangeCount > 0) {
-                  const rect = selection.getRangeAt(0).getBoundingClientRect();
-                  setAnchorRect(rect ?? null);
-                } else {
-                  setAnchorRect(null);
-                }
-              } catch (err) {
-                console.warn("Failed to read selection", err);
-                setAnchorRect(null);
-              }
-              show();
-            }}
+            onSelectAyah={(ayah) => handleAyahSelection(ayah)}
             onSwipe={(direction) => (direction === "next" ? goNext() : goPrev())}
             fontSize={fontSize}
+          />
+        )}
+        {!loading && !error && ayat.length > 0 && viewMode === "translation" && (
+          <QuranTranslationView
+            ayat={ayat}
+            translations={translationMap}
+            loading={translationsLoading}
+            error={translationsError}
+            onRetry={() => refreshTranslations(currentSurahId).catch(() => undefined)}
+            activeAyah={activeAyah}
+            onSelectAyah={(ayah, rect) => handleAyahSelection(ayah, rect)}
           />
         )}
       </div>
@@ -196,7 +277,7 @@ function QuranModernPage() {
         onToggleMode={() => navigate(`/quran/classic?surah=${currentSurahId}`)}
         onSelectSurah={(id) => {
           setCurrentSurahId(id);
-          navigate(`?surah=${id}`);
+          navigateToSurah(id);
         }}
         onPrev={goPrev}
         onNext={goNext}

--- a/front/src/types/quran.ts
+++ b/front/src/types/quran.ts
@@ -16,6 +16,13 @@ export type Ayah = {
   hizb?: number;
 };
 
+export type AyahTranslation = {
+  surah_id: number;
+  ayah_number: number;
+  text: string;
+  source?: string;
+};
+
 export type Tafsir = {
   surah_id: number;
   ayah_number: number;


### PR DESCRIPTION
## Summary
- add a reading preference switcher to the modern Quran page that syncs with the URL and stored reading position
- introduce a dedicated translation view that renders ayat with cached translations and reuses tafsir/audio interactions
- add a client hook for fetching and caching surah translations and extend shared types to cover translation metadata

## Testing
- npm run lint *(fails: existing any-typed usages in AdminTable/useQuranContent)*

------
https://chatgpt.com/codex/tasks/task_e_68f47396a86c832db6f9bd0113683cf3