### PR TITLE
Display Bismillah in classic Quran view when needed

### DIFF
--- a/front/src/components/QuranCanvas.tsx
+++ b/front/src/components/QuranCanvas.tsx
@@ -10,7 +10,7 @@ type Props = {
   fontSize?: number;
 };
 
-const BISMILLAH_TEXT = "بِسْمِ اللَّهِ الرَّحْمَٰنِ الرَّحِيمِ";
+export const BISMILLAH_TEXT = "بِسْمِ اللَّهِ الرَّحْمَٰنِ الرَّحِيمِ";
 
 const chunkAyat = (items: Ayah[], size: number) => {
   const result: Ayah[][] = [];

--- a/front/src/pages/quran/Classic.tsx
+++ b/front/src/pages/quran/Classic.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import type { Ayah } from "../../types/quran";
 import { useQuranSurah, useSurahIndex } from "../../hooks/useQuranContent";
+import { BISMILLAH_TEXT } from "../../components/QuranCanvas";
 
 function useQuery() {
   return new URLSearchParams(useLocation().search);
@@ -31,6 +32,11 @@ function QuranClassicPage() {
 
   const ayat: Ayah[] = data?.ayat ?? [];
   const surah = data?.surah;
+
+  const shouldRenderBismillah =
+    Boolean(surah?.bismillah_pre) &&
+    ayat.length > 0 &&
+    ayat[0]?.text_ar?.replace(/\s+/g, "") !== BISMILLAH_TEXT.replace(/\s+/g, "");
 
   return (
     <div className="min-h-screen bg-white text-black p-10" dir="rtl">
@@ -62,6 +68,9 @@ function QuranClassicPage() {
         )}
         {!loading && !error && ayat.length > 0 && (
           <article className="prose prose-lg rtl:text-right">
+            {shouldRenderBismillah && (
+              <p className="text-2xl leading-loose text-center">{BISMILLAH_TEXT}</p>
+            )}
             {ayat.map((ayah) => (
               <p key={ayah.ayah_number} className="text-2xl leading-loose">
                 <span className="align-top rounded-full border border-gray-400 px-2 py-1 text-sm">{ayah.ayah_number}</span>


### PR DESCRIPTION
## Summary
- export the shared Bismillah text constant from the Quran canvas component
- render the Bismillah at the top of the classic Quran page when the surah requires it and the first ayah does not already contain it

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f468b0c0dc832d8e7f7da94aad93df