### PR TITLE
Handle transient ayah fetch failures

### DIFF
--- a/back/package.json
+++ b/back/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "ts-node-dev --respawn --transpile-only src/server.ts",
     "build": "tsc -p tsconfig.json",
+    "test": "tsc -p tsconfig.json && node --test dist/services/__tests__/quranRemoteService.test.js",
     "start": "node dist/server.js",
     "lint": "eslint . --ext .ts",
     "format": "prettier --write ."

--- a/back/src/services/__tests__/quranRemoteService.test.ts
+++ b/back/src/services/__tests__/quranRemoteService.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import { mock, test } from "node:test";
+
+import {
+  FAILED_AYAT_RETRY_DELAY_MS,
+  fetchSurahAyat
+} from "../quranRemoteService.js";
+
+const SURAH_ID = 9999;
+
+test("retries remote ayat fetch after failure window expires", async (t) => {
+  let callCount = 0;
+  const fetchMock = mock.fn(async () => {
+    callCount += 1;
+    if (callCount === 1) {
+      return {
+        ok: false,
+        status: 500
+      } as any;
+    }
+
+    return {
+      ok: true,
+      status: 200,
+      async json() {
+        return {
+          data: {
+            ayahs: [
+              {
+                numberInSurah: 1,
+                text: "بِسْمِ اللّٰهِ الرَّحْمٰنِ الرَّحِيْمِ"
+              }
+            ]
+          }
+        };
+      }
+    } as any;
+  });
+
+  mock.method(global, "fetch", fetchMock);
+
+  mock.timers.enable({ apis: ["Date"], now: 0 });
+
+  t.after(() => {
+    mock.restoreAll();
+    mock.timers.reset();
+  });
+
+  const firstAttempt = await fetchSurahAyat(SURAH_ID);
+  assert.equal(fetchMock.mock.callCount(), 1, "first attempt should call fetch once");
+  assert.deepEqual(firstAttempt.ayat, [], "first attempt falls back to empty result");
+
+  mock.timers.tick(FAILED_AYAT_RETRY_DELAY_MS + 1);
+
+  const secondAttempt = await fetchSurahAyat(SURAH_ID);
+  assert.equal(fetchMock.mock.callCount(), 2, "second attempt should re-call remote API");
+  assert.equal(secondAttempt.fromCache, false, "second attempt should not be cached");
+  assert.equal(secondAttempt.ayat.length, 1, "remote ayat should populate cache");
+  assert.equal(secondAttempt.ayat[0]?.text_ar, "بِسْمِ اللّٰهِ الرَّحْمٰنِ الرَّحِيْمِ");
+});

--- a/back/src/services/quranRemoteService.ts
+++ b/back/src/services/quranRemoteService.ts
@@ -5,6 +5,9 @@ const API_BASE = "https://api.alquran.cloud/v1";
 
 let cachedSurahIndex: Surah[] | null = null;
 const cachedAyat = new Map<number, Ayah[]>();
+const failedAyatFetches = new Map<number, number>();
+
+export const FAILED_AYAT_RETRY_DELAY_MS = 60_000;
 
 function mapSurah(item: any): Surah {
   return {
@@ -50,9 +53,20 @@ export async function fetchSurahIndex(): Promise<{ surahs: Surah[]; fromCache: b
   }
 }
 
-export async function fetchSurahAyat(surahId: number): Promise<{ ayat: Ayah[]; fromCache: boolean }> {
+export async function fetchSurahAyat(
+  surahId: number
+): Promise<{ ayat: Ayah[]; fromCache: boolean }> {
   if (cachedAyat.has(surahId)) {
     return { ayat: cachedAyat.get(surahId)! as Ayah[], fromCache: true };
+  }
+
+  const lastFailure = failedAyatFetches.get(surahId);
+  if (typeof lastFailure === "number") {
+    const elapsed = Date.now() - lastFailure;
+    if (elapsed < FAILED_AYAT_RETRY_DELAY_MS) {
+      return { ayat: [], fromCache: true };
+    }
+    failedAyatFetches.delete(surahId);
   }
 
   try {
@@ -68,16 +82,18 @@ export async function fetchSurahAyat(surahId: number): Promise<{ ayat: Ayah[]; f
       throw new Error("Empty ayah list from API");
     }
     cachedAyat.set(surahId, verses);
+    failedAyatFetches.delete(surahId);
     return { ayat: verses, fromCache: false };
   } catch (error) {
     console.error(`Remote surah ${surahId} failed`, error);
     const fallback = getAyat().filter((item) => item.surah_id === surahId);
     if (!fallback.length) {
       console.warn(`No local fallback for surah ${surahId}`);
-      cachedAyat.set(surahId, []);
+      failedAyatFetches.set(surahId, Date.now());
       return { ayat: [], fromCache: true };
     }
     cachedAyat.set(surahId, fallback);
+    failedAyatFetches.delete(surahId);
     return { ayat: fallback, fromCache: true };
   }
 }


### PR DESCRIPTION
## Summary
- avoid caching empty ayah responses and track failed fetch timestamps so retries are allowed
- expose the retry window and update the ayah fetcher to retry after failures
- add a node:test suite that simulates a failed remote call and verifies a later retry succeeds
- wire up an npm test script that builds the project before running the new test

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f468ad1af4832db71f47d92fc9a748